### PR TITLE
simple sdc file added to see some timing violation

### DIFF
--- a/gowin_flipflop_drainer.gprj
+++ b/gowin_flipflop_drainer.gprj
@@ -12,5 +12,6 @@
         <File path="src/pll.v" type="file.verilog" enable="1"/>
         <File path="src/top.v" type="file.verilog" enable="1"/>
         <File path="src/pin_constraints.cst" type="file.cst" enable="1"/>
+        <File path="src/constraints.sdc" type="file.sdc" enable="1"/>
     </FileList>
 </Project>

--- a/impl/pnr/gowin_flipflop_drainer.rpt.txt
+++ b/impl/pnr/gowin_flipflop_drainer.rpt.txt
@@ -5,32 +5,32 @@
 1. PnR Messages
 
   <Report Title>: PnR Report
-  <Design File>: C:\fpga\gowin_flipflop_drainer\impl\gwsynthesis\gowin_flipflop_drainer.vg
-  <Physical Constraints File>: C:\fpga\gowin_flipflop_drainer\src\pin_constraints.cst
-  <Timing Constraints File>: ---
-  <PnR Version>: V1.9.8.09
+  <Design File>: /home/stche/Documents/Projets/FPGA/issue/gowin_flipflop_drainer/impl/gwsynthesis/gowin_flipflop_drainer.vg
+  <Physical Constraints File>: /home/stche/Documents/Projets/FPGA/issue/gowin_flipflop_drainer/src/pin_constraints.cst
+  <Timing Constraints File>: /home/stche/Documents/Projets/FPGA/issue/gowin_flipflop_drainer/src/constraints.sdc
+  <PnR Version>: V1.9.8.09 Education
   <Part Number>: GW1NR-LV9QN88PC6/I5
   <Device>: GW1NR-9C
-  <Created Time>:Wed Jan 04 20:46:49 2023
+  <Created Time>:Sat Apr 22 19:35:38 2023
 
 
 2. PnR Details
 
   Running placement:
-    Placement Phase 0: CPU time = 0h 0m 0.311s, Elapsed time = 0h 0m 0.31s
-    Placement Phase 1: CPU time = 0h 0m 0.124s, Elapsed time = 0h 0m 0.124s
-    Placement Phase 2: CPU time = 0h 0m 0.843s, Elapsed time = 0h 0m 0.844s
-    Placement Phase 3: CPU time = 0h 0m 1s, Elapsed time = 0h 0m 1s
-    Total Placement: CPU time = 0h 0m 2s, Elapsed time = 0h 0m 2s
+    Placement Phase 0: CPU time = 0h 0m 2s, Elapsed time = 0h 0m 2s
+    Placement Phase 1: CPU time = 0h 0m 0.415s, Elapsed time = 0h 0m 0.41s
+    Placement Phase 2: CPU time = 0h 0m 3s, Elapsed time = 0h 0m 3s
+    Placement Phase 3: CPU time = 0h 0m 7s, Elapsed time = 0h 0m 6s
+    Total Placement: CPU time = 0h 0m 12s, Elapsed time = 0h 0m 12s
  Running routing:
-    Routing Phase 0: CPU time = 0h 0m 0.002s, Elapsed time = 0h 0m 0.002s
-    Routing Phase 1: CPU time = 0h 0m 2s, Elapsed time = 0h 0m 2s
-    Routing Phase 2: CPU time = 0h 0m 2s, Elapsed time = 0h 0m 2s
-    Total Routing: CPU time = 0h 0m 4s, Elapsed time = 0h 0m 4s
+    Routing Phase 0: CPU time = 0h 0m 0.004s, Elapsed time = 0h 0m 0.004s
+    Routing Phase 1: CPU time = 0h 0m 9s, Elapsed time = 0h 0m 8s
+    Routing Phase 2: CPU time = 0h 0m 12s, Elapsed time = 0h 0m 11s
+    Total Routing: CPU time = 0h 0m 20s, Elapsed time = 0h 0m 20s
  Generate output files:
-    CPU time = 0h 0m 0.974s, Elapsed time = 0h 0m 0.974s
+    CPU time = 0h 0m 2s, Elapsed time = 0h 0m 2s
 
- Total Time and Memory Usage: CPU time = 0h 0m 7s, Elapsed time = 0h 0m 7s, Peak memory usage = 416MB
+ Total Time and Memory Usage: CPU time = 0h 0m 34s, Elapsed time = 0h 0m 34s, Peak memory usage = 1007MB
 
 
 3. Resource Usage Summary
@@ -38,25 +38,25 @@
   ----------------------------------------------------------
   Resources                   | Usage
   ----------------------------------------------------------
-  Logic                       | 5285/8640  61%
-    --LUT,ALU,ROM16           | 5195(362 LUT, 4833 ALU, 0 ROM16)
-    --SSRAM(RAM16)            | 15
-  Register                    | 4418/6693  66%
+  Logic                       | 5280/8640  61%
+    --LUT,ALU,ROM16           | 5196(363 LUT, 4833 ALU, 0 ROM16)
+    --SSRAM(RAM16)            | 14
+  Register                    | 4416/6693  65%
     --Logic Register as Latch | 0/6480  0%
-    --Logic Register as FF    | 4417/6480  68%
+    --Logic Register as FF    | 4415/6480  68%
     --I/O Register as Latch   | 0/213  0%
     --I/O Register as FF      | 1/213  1%
-  CLS                         | 3294/4320  76%
+  CLS                         | 3287/4320  76%
   I/O Port                    | 10
   I/O Buf                     | 6
     --Input Buf               | 1
     --Output Buf              | 5
     --Inout Buf               | 0
-  IOLOGIC                     | 6%
-    --OSER10                  | 3
+  IOLOGIC                     | 8%
+    --OSER10                  | 4
   BSRAM                       | 0%
   DSP                         | 0%
-  PLL                         | 2/2  100%
+  PLL                         | 1/2  50%
   DCS                         | 0/8  0%
   DQCE                        | 0/24  0%
   OSC                         | 0/1  0%
@@ -85,10 +85,10 @@
   -------------------------------
   Global Clock  | Usage       
   -------------------------------
-  PRIMARY       | 3/8(37%)
+  PRIMARY       | 2/8(25%)
   LW            | 1/8(12%)
   GCLK_PIN      | 2/4(50%)
-  PLL           | 2/2(100%)
+  PLL           | 1/2(50%)
   CLKDIV        | 1/8(12%)
   DLLDLY        | 0/8(0%)
   ===============================
@@ -99,10 +99,9 @@
   -------------------------------------------
   Signal         | Global Clock   | Location
   -------------------------------------------
-  clk_d          | PRIMARY        |  TR TL
+  clk_d          | PRIMARY        |  TR TL BR BL
   hdmi_clk       | PRIMARY        |  TR BR
-  adder_clk[0]   | PRIMARY        |  TR TL BR BL
-  n46_6          | LW             |  -
+  n47_6          | LW             |  -
   hdmi_clk_5x    | HCLK           | TOP[0]
   ===========================================
 

--- a/impl/pnr/gowin_flipflop_drainer.tr
+++ b/impl/pnr/gowin_flipflop_drainer.tr
@@ -41,139 +41,127 @@ Note:Core Timing Report
 
 1. Timing Messages
 <Report Title>: Timing Analysis Report
-<Design File>: C:\fpga\gowin_flipflop_drainer\impl\gwsynthesis\gowin_flipflop_drainer.vg
-<Physical Constraints File>: C:\fpga\gowin_flipflop_drainer\src\pin_constraints.cst
-<Timing Constraints File>: ---
-<Version>: V1.9.8.09
+<Design File>: /home/stche/Documents/Projets/FPGA/issue/gowin_flipflop_drainer/impl/gwsynthesis/gowin_flipflop_drainer.vg
+<Physical Constraints File>: /home/stche/Documents/Projets/FPGA/issue/gowin_flipflop_drainer/src/pin_constraints.cst
+<Timing Constraints File>: /home/stche/Documents/Projets/FPGA/issue/gowin_flipflop_drainer/src/constraints.sdc
+<Version>: V1.9.8.09 Education
 <Part Number>: GW1NR-LV9QN88PC6/I5
 <Device>: GW1NR-9C
-<Created Time>: Wed Jan 04 20:46:49 2023
+<Created Time>: Sat Apr 22 19:35:39 2023
 
 
 2. Timing Summaries
 2.1 STA Tool Run Summary
 <Setup Delay Model>:Slow 1.14V 85C C6/I5
 <Hold Delay Model>:Fast 1.26V 0C C6/I5
-<Numbers of Paths Analyzed>:11320
-<Numbers of Endpoints Analyzed>:4723
+<Numbers of Paths Analyzed>:6558
+<Numbers of Endpoints Analyzed>:4728
 <Numbers of Falling Endpoints>:0
-<Numbers of Setup Violated Endpoints>:0
+<Numbers of Setup Violated Endpoints>:18
 <Numbers of Hold Violated Endpoints>:0
 
 2.2 Clock Summary
-                Clock Name                   Type      Period    Frequency    Rise     Fall           Source                        Master                          Objects          
- ======================================== =========== ========= ============ ======= ========= ===================== ===================================== ========================= 
-  clk                                      Base        37.037    27.000MHz    0.000   18.519                                                                clk_ibuf/I               
-  adder_pll/pll/CLKOUT.default_gen_clk     Generated   185.185   5.400MHz     0.000   92.593    clk_ibuf/I            clk                                   adder_pll/pll/CLKOUT     
-  adder_pll/pll/CLKOUTP.default_gen_clk    Generated   185.185   5.400MHz     0.000   92.593    clk_ibuf/I            clk                                   adder_pll/pll/CLKOUTP    
-  adder_pll/pll/CLKOUTD.default_gen_clk    Generated   370.370   2.700MHz     0.000   185.185   clk_ibuf/I            clk                                   adder_pll/pll/CLKOUTD    
-  adder_pll/pll/CLKOUTD3.default_gen_clk   Generated   555.556   1.800MHz     0.000   277.778   clk_ibuf/I            clk                                   adder_pll/pll/CLKOUTD3   
-  hdmi_pll/pll/CLKOUT.default_gen_clk      Generated   1.883     531.000MHz   0.000   0.942     clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUT      
-  hdmi_pll/pll/CLKOUTP.default_gen_clk     Generated   1.883     531.000MHz   0.000   0.942     clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUTP     
-  hdmi_pll/pll/CLKOUTD.default_gen_clk     Generated   3.766     265.500MHz   0.000   1.883     clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUTD     
-  hdmi_pll/pll/CLKOUTD3.default_gen_clk    Generated   5.650     177.000MHz   0.000   2.825     clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUTD3    
-  hdmi_clock_div/CLKOUT.default_gen_clk    Generated   9.416     106.200MHz   0.000   4.708     hdmi_pll/pll/CLKOUT   hdmi_pll/pll/CLKOUT.default_gen_clk   hdmi_clock_div/CLKOUT    
+               Clock Name                   Type      Period   Frequency    Rise     Fall          Source                        Master                                                                                                                                                                    Objects                                                                                                                                                     
+ ======================================= =========== ======== ============ ======= ======== ===================== ===================================== ============================================================================================================================================================================================================================================================================================================== 
+  clk                                     Base        37.000   27.027MHz    0.000   18.000                                                               clk                                                                                                                                                                                                                                                                                                           
+  hdmi_clk_5x                             Generated   3.083    324.324MHz   0.000   1.542    clk                   clk                                   hdmi_out/encode_r/o_tmds_0_s0 hdmi_out/encode_r/o_tmds_1_s0 hdmi_out/encode_r/o_tmds_2_s0 hdmi_out/encode_r/o_tmds_3_s0 hdmi_out/encode_r/o_tmds_4_s0 hdmi_out/encode_r/o_tmds_5_s0 hdmi_out/encode_r/o_tmds_6_s0 hdmi_out/encode_r/o_tmds_7_s0 hdmi_out/encode_r/o_tmds_8_s0 hdmi_out/encode_r/o_tmds_9_s0   
+  hdmi_pll/pll/CLKOUT.default_gen_clk     Generated   3.083    324.324MHz   0.000   1.542    clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUT                                                                                                                                                                                                                                                                                           
+  hdmi_pll/pll/CLKOUTP.default_gen_clk    Generated   3.083    324.324MHz   0.000   1.542    clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUTP                                                                                                                                                                                                                                                                                          
+  hdmi_pll/pll/CLKOUTD.default_gen_clk    Generated   6.167    162.162MHz   0.000   3.083    clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUTD                                                                                                                                                                                                                                                                                          
+  hdmi_pll/pll/CLKOUTD3.default_gen_clk   Generated   9.250    108.108MHz   0.000   4.625    clk_ibuf/I            clk                                   hdmi_pll/pll/CLKOUTD3                                                                                                                                                                                                                                                                                         
+  hdmi_clock_div/CLKOUT.default_gen_clk   Generated   15.417   64.865MHz    0.000   7.708    hdmi_pll/pll/CLKOUT   hdmi_pll/pll/CLKOUT.default_gen_clk   hdmi_clock_div/CLKOUT                                                                                                                                                                                                                                                                                         
 
 2.3 Max Frequency Summary
-  NO.                Clock Name                  Constraint    Actual Fmax    Level   Entity  
- ===== ======================================= ============== ============== ======= ======== 
-  1     adder_pll/pll/CLKOUT.default_gen_clk    5.400(MHz)     128.750(MHz)   3       TOP     
-  2     hdmi_clock_div/CLKOUT.default_gen_clk   106.200(MHz)   134.571(MHz)   4       TOP     
-No timing paths to get frequency of clk!
-No timing paths to get frequency of adder_pll/pll/CLKOUTP.default_gen_clk!
-No timing paths to get frequency of adder_pll/pll/CLKOUTD.default_gen_clk!
-No timing paths to get frequency of adder_pll/pll/CLKOUTD3.default_gen_clk!
+  NO.                Clock Name                 Constraint    Actual Fmax    Level   Entity  
+ ===== ======================================= ============= ============== ======= ======== 
+  1     clk                                     27.027(MHz)   128.750(MHz)   3       TOP     
+  2     hdmi_clock_div/CLKOUT.default_gen_clk   64.865(MHz)   138.477(MHz)   5       TOP     
+No timing paths to get frequency of hdmi_clk_5x!
 No timing paths to get frequency of hdmi_pll/pll/CLKOUT.default_gen_clk!
 No timing paths to get frequency of hdmi_pll/pll/CLKOUTP.default_gen_clk!
 No timing paths to get frequency of hdmi_pll/pll/CLKOUTD.default_gen_clk!
 No timing paths to get frequency of hdmi_pll/pll/CLKOUTD3.default_gen_clk!
 
 2.4 Total Negative Slack Summary
-                Clock Name                 Analysis Type   EndPoints TNS   Number of EndPoints  
- ======================================== =============== =============== ===================== 
-  clk                                      setup           0.000           0                    
-  clk                                      hold            0.000           0                    
-  adder_pll/pll/CLKOUT.default_gen_clk     setup           0.000           0                    
-  adder_pll/pll/CLKOUT.default_gen_clk     hold            0.000           0                    
-  adder_pll/pll/CLKOUTP.default_gen_clk    setup           0.000           0                    
-  adder_pll/pll/CLKOUTP.default_gen_clk    hold            0.000           0                    
-  adder_pll/pll/CLKOUTD.default_gen_clk    setup           0.000           0                    
-  adder_pll/pll/CLKOUTD.default_gen_clk    hold            0.000           0                    
-  adder_pll/pll/CLKOUTD3.default_gen_clk   setup           0.000           0                    
-  adder_pll/pll/CLKOUTD3.default_gen_clk   hold            0.000           0                    
-  hdmi_pll/pll/CLKOUT.default_gen_clk      setup           0.000           0                    
-  hdmi_pll/pll/CLKOUT.default_gen_clk      hold            0.000           0                    
-  hdmi_pll/pll/CLKOUTP.default_gen_clk     setup           0.000           0                    
-  hdmi_pll/pll/CLKOUTP.default_gen_clk     hold            0.000           0                    
-  hdmi_pll/pll/CLKOUTD.default_gen_clk     setup           0.000           0                    
-  hdmi_pll/pll/CLKOUTD.default_gen_clk     hold            0.000           0                    
-  hdmi_pll/pll/CLKOUTD3.default_gen_clk    setup           0.000           0                    
-  hdmi_pll/pll/CLKOUTD3.default_gen_clk    hold            0.000           0                    
-  hdmi_clock_div/CLKOUT.default_gen_clk    setup           0.000           0                    
-  hdmi_clock_div/CLKOUT.default_gen_clk    hold            0.000           0                    
+               Clock Name                 Analysis Type   EndPoints TNS   Number of EndPoints  
+ ======================================= =============== =============== ===================== 
+  clk                                     setup           0.000           0                    
+  clk                                     hold            0.000           0                    
+  hdmi_clk_5x                             setup           0.000           0                    
+  hdmi_clk_5x                             hold            0.000           0                    
+  hdmi_pll/pll/CLKOUT.default_gen_clk     setup           0.000           0                    
+  hdmi_pll/pll/CLKOUT.default_gen_clk     hold            0.000           0                    
+  hdmi_pll/pll/CLKOUTP.default_gen_clk    setup           0.000           0                    
+  hdmi_pll/pll/CLKOUTP.default_gen_clk    hold            0.000           0                    
+  hdmi_pll/pll/CLKOUTD.default_gen_clk    setup           0.000           0                    
+  hdmi_pll/pll/CLKOUTD.default_gen_clk    hold            0.000           0                    
+  hdmi_pll/pll/CLKOUTD3.default_gen_clk   setup           0.000           0                    
+  hdmi_pll/pll/CLKOUTD3.default_gen_clk   hold            0.000           0                    
+  hdmi_clock_div/CLKOUT.default_gen_clk   setup           0.000           0                    
+  hdmi_clock_div/CLKOUT.default_gen_clk   hold            0.000           0                    
 
 
 3. Timing Details
 3.1 Path Slacks Table
 3.1.1 Setup Paths Table
 <Report Command>:report_timing -setup -max_paths 25 -max_common_paths 1
-  Path Number   Path Slack             From Node                            To Node                                 From Clock                                   To Clock                    Relation   Clock Skew   Data Delay  
- ============= ============ ================================ ====================================== =========================================== =========================================== ========== ============ ============ 
-  1             1.985        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_b/shl18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        7.031       
-  2             2.019        hdmi_out/encode_b/shr18_0_s0/Q   hdmi_out/encode_b/bias_1_s0/D          hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.997       
-  3             2.166        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_r/shl18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.850       
-  4             2.166        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_r/inv18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.850       
-  5             2.297        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shr18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.720       
-  6             2.297        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/inv18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.720       
-  7             2.300        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shl18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.716       
-  8             2.376        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_r/shr18_3_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.640       
-  9             2.437        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_b/tmds_pos18_2_s0/D    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.579       
-  10            2.511        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_0_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.505       
-  11            2.511        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_1_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.505       
-  12            2.511        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_5_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.505       
-  13            2.511        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_6_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.505       
-  14            2.531        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shl18_0_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.486       
-  15            2.531        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shl18_1_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.486       
-  16            2.531        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shr18_0_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.486       
-  17            2.531        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/inv18_1_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.486       
-  18            2.540        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shl18_2_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.476       
-  19            2.560        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_4_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.456       
-  20            2.578        ds/x_5_s0/Q                      ds/y_0_s0/RESET                        hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.795       
-  21            2.578        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_2_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.438       
-  22            2.578        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/tmds_even18_3_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.438       
-  23            2.602        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_b/tmds_even18_2_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.415       
-  24            2.607        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/shr18_2_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.409       
-  25            2.607        hdmi_out/encode_b/enc11_0_s2/Q   hdmi_out/encode_g/inv18_2_s0/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   9.416      0.000        6.409       
+  Path Number   Path Slack                From Node                               To Node                                From Clock                                   To Clock                    Relation   Clock Skew   Data Delay  
+ ============= ============ ====================================== ===================================== =========================================== =========================================== ========== ============ ============ 
+  1             -3.539       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_9_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        5.620       
+  2             -2.435       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_7_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.516       
+  3             -2.383       hdmi_out/encode_r/tmds_neg18_3_s0/Q    hdmi_out/encode_r/o_tmds_3_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.464       
+  4             -2.373       hdmi_out/encode_r/tmds_neg18_2_s0/Q    hdmi_out/encode_r/o_tmds_2_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.454       
+  5             -2.181       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_1_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.262       
+  6             -2.181       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_4_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.262       
+  7             -2.181       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_5_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.262       
+  8             -2.181       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_6_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        4.262       
+  9             -1.781       hdmi_out/encode_r/bias_1_s0/Q          hdmi_out/encode_r/o_tmds_0_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        3.862       
+  10            -0.455       hdmi_out/encode_r/tmds_even18_8_s0/Q   hdmi_out/encode_r/o_tmds_8_s0/D       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.536       
+  11            -0.277       hdmi_out/encode_r/o_tmds_6_s0/Q        hdmi_out/ser_c2/D6                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  12            -0.277       hdmi_out/encode_r/o_tmds_5_s0/Q        hdmi_out/ser_c2/D5                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  13            -0.277       hdmi_out/encode_r/o_tmds_4_s0/Q        hdmi_out/ser_c2/D4                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  14            -0.277       hdmi_out/encode_r/o_tmds_3_s0/Q        hdmi_out/ser_c2/D3                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  15            -0.277       hdmi_out/encode_r/o_tmds_2_s0/Q        hdmi_out/ser_c2/D2                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  16            -0.277       hdmi_out/encode_r/o_tmds_1_s0/Q        hdmi_out/ser_c2/D1                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  17            -0.277       hdmi_out/encode_r/o_tmds_0_s0/Q        hdmi_out/ser_c2/D0                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.858       
+  18            -0.030       hdmi_out/encode_b/not_den18_s0/Q       hdmi_out/encode_r/o_tmds_8_s0/SET     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.468       
+  19            0.037        hdmi_out/encode_r/o_tmds_9_s0/Q        hdmi_out/ser_c2/D9                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.543       
+  20            0.207        hdmi_out/encode_r/o_tmds_7_s0/Q        hdmi_out/ser_c2/D7                    hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   3.083      -0.572       3.373       
+  21            0.252        hdmi_out/encode_b/not_den18_s0/Q       hdmi_out/encode_r/o_tmds_1_s0/RESET   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.186       
+  22            0.252        hdmi_out/encode_b/not_den18_s0/Q       hdmi_out/encode_r/o_tmds_4_s0/SET     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.186       
+  23            0.252        hdmi_out/encode_b/not_den18_s0/Q       hdmi_out/encode_r/o_tmds_5_s0/RESET   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.186       
+  24            0.252        hdmi_out/encode_b/not_den18_s0/Q       hdmi_out/encode_r/o_tmds_6_s0/SET     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.186       
+  25            0.267        hdmi_out/encode_b/not_den18_s0/Q       hdmi_out/encode_r/o_tmds_0_s0/RESET   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clk_5x:[R]                             3.083      0.572        2.171       
 
 3.1.2 Hold Paths Table
 <Report Command>:report_timing -hold -max_paths 25 -max_common_paths 1
-  Path Number   Path Slack             From Node                            To Node                                From Clock                                   To Clock                    Relation   Clock Skew   Data Delay  
- ============= ============ ================================ ===================================== =========================================== =========================================== ========== ============ ============ 
-  1             0.550        hdmi_out/encode_b/ctl2_0_s0/Q    hdmi_out/encode_b/ctl3_0_s9/DI[0]     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.565       
-  2             0.553        hdmi_out/encode_r/enc10_6_s0/Q   hdmi_out/encode_b/enc11_0_s12/DI[2]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.568       
-  3             0.553        hdmi_out/encode_b/enc10_4_s0/Q   hdmi_out/encode_b/enc11_0_s8/DI[0]    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.568       
-  4             0.556        hdmi_out/encode_r/enc10_1_s0/Q   hdmi_out/encode_r/tpb11_1_s0/RESET    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
-  5             0.556        hdmi_out/encode_r/enc10_3_s0/Q   hdmi_out/encode_r/tpb11_3_s0/RESET    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
-  6             0.556        hdmi_out/encode_b/enc10_1_s0/Q   hdmi_out/encode_b/tpb11_1_s0/RESET    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
-  7             0.556        hdmi_out/encode_b/enc10_3_s0/Q   hdmi_out/encode_b/tpb11_3_s0/RESET    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
-  8             0.569        hdmi_out/encode_b/enc11_0_s6/Q   hdmi_out/encode_r/den2_s10/AD[2]      hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.584       
-  9             0.572        hdmi_out/encode_b/enc11_0_s4/Q   hdmi_out/encode_r/den2_s10/AD[1]      hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.587       
-  10            0.584        hdmi_out/encode_b/dat4_4_s0/Q    hdmi_out/encode_b/par5_1_s0/SET       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.599       
-  11            0.587        hdmi_out/encode_b/ctl3_0_s8/Q    hdmi_out/encode_r/den2_s10/AD[3]      hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.602       
-  12            0.588        hdmi_out/encode_b/dat2_2_s0/Q    hdmi_out/encode_b/par3_1_s0/SET       hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.603       
-  13            0.588        hdmi_out/encode_b/dat2_2_s0/Q    hdmi_out/encode_b/par3_2_s0/RESET     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.603       
-  14            0.708        hdmi_out/encode_b/par9_s8/Q      hdmi_out/encode_b/par9_s8/D           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.708       
-  15            0.709        ds/y_0_s0/Q                      ds/y_0_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.709       
-  16            0.709        ds/x_0_s0/Q                      ds/x_0_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.709       
-  17            0.710        hdmi_out/encode_b/ctl3_0_s8/Q    hdmi_out/encode_b/ctl3_0_s8/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.710       
-  18            0.711        hdmi_out/encode_b/dat3_7_s6/Q    hdmi_out/encode_b/dat3_7_s6/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.711       
-  19            0.714        hdmi_out/encode_b/enc11_0_s6/Q   hdmi_out/encode_b/enc11_0_s6/D        hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.714       
-  20            0.730        ds/y_6_s0/Q                      ds/y_6_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.730       
-  21            0.730        ds/y_8_s0/Q                      ds/y_8_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.730       
-  22            0.730        ds/x_2_s0/Q                      ds/x_2_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.730       
-  23            0.731        ds/x_12_s0/Q                     ds/x_12_s0/D                          hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.731       
-  24            0.731        ds/y_12_s0/Q                     ds/y_12_s0/D                          hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.731       
-  25            0.732        ds/y_2_s0/Q                      ds/y_2_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.732       
+  Path Number   Path Slack              From Node                            To Node                                 From Clock                                   To Clock                    Relation   Clock Skew   Data Delay  
+ ============= ============ ================================= ====================================== =========================================== =========================================== ========== ============ ============ 
+  1             0.556        hdmi_out/encode_r/enc10_3_s0/Q    hdmi_out/encode_r/tpb11_3_s0/RESET     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
+  2             0.556        hdmi_out/encode_g/dat3_3_s0/Q     hdmi_out/encode_g/par4_1_s0/SET        hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
+  3             0.556        hdmi_out/encode_b/enc10_3_s0/Q    hdmi_out/encode_b/tpb11_3_s0/RESET     hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
+  4             0.556        hdmi_out/encode_b/dat3_3_s0/Q     hdmi_out/encode_b/par4_1_s0/SET        hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.571       
+  5             0.557        hdmi_out/encode_b/dat4_4_s0/Q     hdmi_out/encode_b/par5_1_s0/SET        hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.572       
+  6             0.562        hdmi_out/encode_r/dat3_3_s0/Q     hdmi_out/encode_r/par4_3_s0/RESET      hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.577       
+  7             0.570        hdmi_out/encode_r/enc7_1_s0/Q     hdmi_out/encode_r/enc8_1_s0/D          hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.570       
+  8             0.570        hdmi_out/encode_r/enc6_5_s0/Q     hdmi_out/encode_r/enc7_5_s0/D          hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.570       
+  9             0.609        hdmi_out/encode_r/o_tmds_8_s0/Q   hdmi_out/ser_c2/D8                     hdmi_clk_5x:[R]                             hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      -0.513       1.167       
+  10            0.708        hdmi_out/encode_b/par9_s8/Q       hdmi_out/encode_b/par9_s8/D            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.708       
+  11            0.712        hdmi_out/encode_b/enc11_0_s4/Q    hdmi_out/encode_b/enc11_0_s4/D         hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.712       
+  12            0.731        ds/y_6_s0/Q                       ds/y_6_s0/D                            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.731       
+  13            0.731        ds/y_8_s0/Q                       ds/y_8_s0/D                            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.731       
+  14            0.731        ds/x_2_s0/Q                       ds/x_2_s0/D                            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.731       
+  15            0.731        ds/x_8_s0/Q                       ds/x_8_s0/D                            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.731       
+  16            0.732        ds/x_12_s0/Q                      ds/x_12_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.732       
+  17            0.732        ds/y_12_s0/Q                      ds/y_12_s0/D                           hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.732       
+  18            0.732        ds/x_6_s0/Q                       ds/x_6_s0/D                            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.732       
+  19            0.733        ds/y_2_s0/Q                       ds/y_2_s0/D                            hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.733       
+  20            0.769        hdmi_out/encode_b/par9_s8/Q       hdmi_out/encode_r/tmds_even18_9_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.769       
+  21            0.769        hdmi_out/encode_b/par9_s8/Q       hdmi_out/encode_g/tmds_even18_9_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.769       
+  22            0.769        hdmi_out/encode_b/par9_s8/Q       hdmi_out/encode_b/tmds_even18_9_s0/D   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.769       
+  23            0.775        hdmi_out/encode_b/enc11_0_s6/Q    hdmi_out/encode_g/tmds_neg18_0_s0/D    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.775       
+  24            0.775        hdmi_out/encode_b/enc11_0_s6/Q    hdmi_out/encode_g/tmds_neg18_1_s0/D    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.775       
+  25            0.775        hdmi_out/encode_b/enc11_0_s6/Q    hdmi_out/encode_g/tmds_neg18_2_s0/D    hdmi_clock_div/CLKOUT.default_gen_clk:[R]   hdmi_clock_div/CLKOUT.default_gen_clk:[R]   0.000      0.000        0.775       
 
 3.1.3 Recovery Paths Table
 <Report Command>:report_timing -recovery -max_paths 25 -max_common_paths 1
@@ -183,1176 +171,1094 @@ Nothing to report!
 Nothing to report!
 3.2 Minimum Pulse Width Table
 Report Command:report_min_pulse_width -nworst 10 -detail
-  Number   Slack   Actual Width   Required Width        Type                         Clock                             Objects            
- ======== ======= ============== ================ ================= ======================================= ============================= 
-  1        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/x_11_s0                   
-  2        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/x_9_s0                    
-  3        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/x_5_s0                    
-  4        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/y_10_s0                   
-  5        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/o_x_2_s0                  
-  6        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/rgb_p_8_s0          
-  7        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_b/par6_2_s0  
-  8        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_b/rst0_s0    
-  9        3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_r/enc6_7_s0  
-  10       3.384   4.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_r/enc5_1_s0  
+  Number   Slack   Actual Width   Required Width        Type                         Clock                                Objects               
+ ======== ======= ============== ================ ================= ======================================= =================================== 
+  1        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/x_11_s0                         
+  2        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/x_10_s0                         
+  3        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/x_9_s0                          
+  4        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   ds/o_y_6_s0                        
+  5        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_b/enc9_5_s0        
+  6        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_b/tmds_pos18_3_s0  
+  7        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_b/ctl2_0_s8        
+  8        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_g/dat1_6_s0        
+  9        6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_g/dat2_6_s0        
+  10       6.384   7.634          1.250            Low Pulse Width   hdmi_clock_div/CLKOUT.default_gen_clk   hdmi_out/encode_g/dat2_2_s0        
 
 3.3 Timing Report By Analysis Type
 3.3.1 Setup Analysis Report
 Report Command:report_timing -setup -max_paths 25 -max_common_paths 1
 						Path1						
 Path Summary:
-Slack             : 1.985
-Data Arrival Time : 7.603
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shl18_3_s0
+Slack             : -3.539
+Data Arrival Time : 6.193
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_9_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.025   1.994   tNET   FF   4        R15C44         hdmi_out/encode_b/dat3_7_s8/RAD[0]     
-  3.284   0.259   tINS   FF   8        R15C44         hdmi_out/encode_b/dat3_7_s8/DO[1]      
-  4.764   1.480   tNET   FF   1        R8C46[3][A]    hdmi_out/encode_b/n104_s2/I2           
-  5.796   1.032   tINS   FF   3        R8C46[3][A]    hdmi_out/encode_b/n104_s2/F            
-  6.781   0.986   tNET   FF   1        R12C46[1][A]   hdmi_out/encode_b/n132_s0/I1           
-  7.603   0.822   tINS   FF   1        R12C46[1][A]   hdmi_out/encode_b/n132_s0/F            
-  7.603   0.000   tNET   FF   1        R12C46[1][A]   hdmi_out/encode_b/shl18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  4.056   1.171   tNET   FF   1        R22C42[3][B]   hdmi_out/encode_r/n196_s2/I1           
+  5.155   1.099   tINS   FF   1        R22C42[3][B]   hdmi_out/encode_r/n196_s2/F            
+  5.161   0.005   tNET   FF   1        R22C42[0][A]   hdmi_out/encode_r/n196_s4/I3           
+  6.193   1.032   tINS   FF   1        R22C42[0][A]   hdmi_out/encode_r/n196_s4/F            
+  6.193   0.000   tNET   FF   1        R22C42[0][A]   hdmi_out/encode_r/o_tmds_9_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R12C46[1][A]   hdmi_out/encode_b/shl18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R12C46[1][A]   hdmi_out/encode_b/shl18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C42[0][A]   hdmi_out/encode_r/o_tmds_9_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_9_s0      
+  2.653   -0.400   tSu         1        R22C42[0][A]   hdmi_out/encode_r/o_tmds_9_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
+Clock Skew: -0.572
+Setup Relationship: 3.083
 Logic Level: 4
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 2.113 30.055%, 
-                    route: 4.460 63.426%, 
-                    tC2Q: 0.458 6.519%)
+Arrival Data Path Delay: (cell: 3.163 56.277%, 
+                    route: 1.999 35.568%, 
+                    tC2Q: 0.458 8.155%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path2						
 Path Summary:
-Slack             : 2.019
-Data Arrival Time : 7.570
-Data Required Time: 9.588
-From              : shr18_0_s0
-To                : bias_1_s0
+Slack             : -2.435
+Data Arrival Time : 5.088
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_7_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R12C46[1][B]   hdmi_out/encode_b/shr18_0_s0/CLK       
-  1.030   0.458   tC2Q   RF   1        R12C46[1][B]   hdmi_out/encode_b/shr18_0_s0/Q         
-  2.653   1.622   tNET   FF   2        R8C42[0][B]    hdmi_out/encode_b/n178_s/I1            
-  3.203   0.550   tINS   FR   1        R8C42[0][B]    hdmi_out/encode_b/n178_s/COUT          
-  3.203   0.000   tNET   RR   2        R8C42[1][A]    hdmi_out/encode_b/n177_s/CIN           
-  3.731   0.528   tINS   RR   1        R8C42[1][A]    hdmi_out/encode_b/n177_s/SUM           
-  4.150   0.419   tNET   RR   1        R8C43[3][A]    hdmi_out/encode_b/n210_s3/I1           
-  5.249   1.099   tINS   RF   1        R8C43[3][A]    hdmi_out/encode_b/n210_s3/F            
-  6.538   1.289   tNET   FF   1        R9C46[2][A]    hdmi_out/encode_b/n210_s2/I0           
-  7.570   1.032   tINS   FF   1        R9C46[2][A]    hdmi_out/encode_b/n210_s2/F            
-  7.570   0.000   tNET   FF   1        R9C46[2][A]    hdmi_out/encode_b/bias_1_s0/D          
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  4.056   1.171   tNET   FF   1        R22C42[0][B]   hdmi_out/encode_r/n198_s3/I3           
+  5.088   1.032   tINS   FF   1        R22C42[0][B]   hdmi_out/encode_r/n198_s3/F            
+  5.088   0.000   tNET   FF   1        R22C42[0][B]   hdmi_out/encode_r/o_tmds_7_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======== ====== ==== ======== ============= ======================================= 
-  9.416   9.416                                       active clock edge time                 
-  9.416   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R9C46[2][A]   hdmi_out/encode_b/bias_1_s0/CLK        
-  9.588   -0.400   tSu         1        R9C46[2][A]   hdmi_out/encode_b/bias_1_s0            
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C42[0][B]   hdmi_out/encode_r/o_tmds_7_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_7_s0      
+  2.653   -0.400   tSu         1        R22C42[0][B]   hdmi_out/encode_r/o_tmds_7_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 5
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 3.209 45.860%, 
-                    route: 3.330 47.590%, 
-                    tC2Q: 0.458 6.550%)
+Arrival Data Path Delay: (cell: 2.064 45.705%, 
+                    route: 1.994 44.146%, 
+                    tC2Q: 0.458 10.149%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path3						
 Path Summary:
-Slack             : 2.166
-Data Arrival Time : 7.422
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shl18_3_s0
+Slack             : -2.383
+Data Arrival Time : 5.037
+Data Required Time: 2.653
+From              : tmds_neg18_3_s0
+To                : o_tmds_3_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.025   1.994   tNET   FF   4        R14C45         hdmi_out/encode_b/dat3_7_s11/RAD[0]    
-  3.284   0.259   tINS   FF   8        R14C45         hdmi_out/encode_b/dat3_7_s11/DO[1]     
-  4.937   1.654   tNET   FF   1        R2C45[3][A]    hdmi_out/encode_r/n104_s2/I2           
-  5.963   1.026   tINS   FR   3        R2C45[3][A]    hdmi_out/encode_r/n104_s2/F            
-  6.390   0.427   tNET   RR   1        R3C45[2][B]    hdmi_out/encode_r/n132_s0/I1           
-  7.422   1.032   tINS   RF   1        R3C45[2][B]    hdmi_out/encode_r/n132_s0/F            
-  7.422   0.000   tNET   FF   1        R3C45[2][B]    hdmi_out/encode_r/shl18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R14C42[1][B]   hdmi_out/encode_r/tmds_neg18_3_s0/CLK  
+  1.030   0.458   tC2Q   RF   1        R14C42[1][B]   hdmi_out/encode_r/tmds_neg18_3_s0/Q    
+  2.483   1.452   tNET   FF   1        R23C43[3][B]   hdmi_out/encode_r/n202_s2/I0           
+  3.515   1.032   tINS   FF   1        R23C43[3][B]   hdmi_out/encode_r/n202_s2/F            
+  4.005   0.490   tNET   FF   1        R23C44[2][A]   hdmi_out/encode_r/n202_s3/I0           
+  5.037   1.032   tINS   FF   1        R23C44[2][A]   hdmi_out/encode_r/n202_s3/F            
+  5.037   0.000   tNET   FF   1        R23C44[2][A]   hdmi_out/encode_r/o_tmds_3_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======== ====== ==== ======== ============= ======================================= 
-  9.416   9.416                                       active clock edge time                 
-  9.416   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R3C45[2][B]   hdmi_out/encode_r/shl18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R3C45[2][B]   hdmi_out/encode_r/shl18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R23C44[2][A]   hdmi_out/encode_r/o_tmds_3_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_3_s0      
+  2.653   -0.400   tSu         1        R23C44[2][A]   hdmi_out/encode_r/o_tmds_3_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 2.317 33.827%, 
-                    route: 4.075 59.483%, 
-                    tC2Q: 0.458 6.691%)
+Arrival Data Path Delay: (cell: 2.064 46.232%, 
+                    route: 1.942 43.502%, 
+                    tC2Q: 0.458 10.266%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path4						
 Path Summary:
-Slack             : 2.166
-Data Arrival Time : 7.422
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : inv18_3_s0
+Slack             : -2.373
+Data Arrival Time : 5.026
+Data Required Time: 2.653
+From              : tmds_neg18_2_s0
+To                : o_tmds_2_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.025   1.994   tNET   FF   4        R14C45         hdmi_out/encode_b/dat3_7_s11/RAD[0]    
-  3.284   0.259   tINS   FF   8        R14C45         hdmi_out/encode_b/dat3_7_s11/DO[1]     
-  4.937   1.654   tNET   FF   1        R2C45[3][A]    hdmi_out/encode_r/n104_s2/I2           
-  5.963   1.026   tINS   FR   3        R2C45[3][A]    hdmi_out/encode_r/n104_s2/F            
-  6.390   0.427   tNET   RR   1        R3C45[2][A]    hdmi_out/encode_r/n114_s0/I0           
-  7.422   1.032   tINS   RF   1        R3C45[2][A]    hdmi_out/encode_r/n114_s0/F            
-  7.422   0.000   tNET   FF   1        R3C45[2][A]    hdmi_out/encode_r/inv18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R14C42[1][A]   hdmi_out/encode_r/tmds_neg18_2_s0/CLK  
+  1.030   0.458   tC2Q   RF   1        R14C42[1][A]   hdmi_out/encode_r/tmds_neg18_2_s0/Q    
+  2.483   1.452   tNET   FF   1        R23C43[3][A]   hdmi_out/encode_r/n203_s2/I0           
+  3.509   1.026   tINS   FR   1        R23C43[3][A]   hdmi_out/encode_r/n203_s2/F            
+  3.927   0.419   tNET   RR   1        R23C44[2][B]   hdmi_out/encode_r/n203_s3/I0           
+  5.026   1.099   tINS   RF   1        R23C44[2][B]   hdmi_out/encode_r/n203_s3/F            
+  5.026   0.000   tNET   FF   1        R23C44[2][B]   hdmi_out/encode_r/o_tmds_2_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======== ====== ==== ======== ============= ======================================= 
-  9.416   9.416                                       active clock edge time                 
-  9.416   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R3C45[2][A]   hdmi_out/encode_r/inv18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R3C45[2][A]   hdmi_out/encode_r/inv18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R23C44[2][B]   hdmi_out/encode_r/o_tmds_2_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_2_s0      
+  2.653   -0.400   tSu         1        R23C44[2][B]   hdmi_out/encode_r/o_tmds_2_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 2.317 33.827%, 
-                    route: 4.075 59.483%, 
-                    tC2Q: 0.458 6.691%)
+Arrival Data Path Delay: (cell: 2.125 47.707%, 
+                    route: 1.871 42.004%, 
+                    tC2Q: 0.458 10.290%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path5						
 Path Summary:
-Slack             : 2.297
-Data Arrival Time : 7.292
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shr18_3_s0
+Slack             : -2.181
+Data Arrival Time : 4.834
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_1_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.035   2.004   tNET   FF   4        R5C45          hdmi_out/encode_b/tpa12_0_s7/RAD[0]    
-  3.294   0.259   tINS   FF   11       R5C45          hdmi_out/encode_b/tpa12_0_s7/DO[1]     
-  5.420   2.126   tNET   FF   1        R23C46[3][A]   hdmi_out/encode_g/n104_s2/I1           
-  6.045   0.625   tINS   FR   3        R23C46[3][A]   hdmi_out/encode_g/n104_s2/F            
-  6.470   0.425   tNET   RR   1        R22C46[2][A]   hdmi_out/encode_g/n123_s0/I1           
-  7.292   0.822   tINS   RF   1        R22C46[2][A]   hdmi_out/encode_g/n123_s0/F            
-  7.292   0.000   tNET   FF   1        R22C46[2][A]   hdmi_out/encode_g/shr18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  3.735   0.850   tNET   FF   1        R22C43[2][A]   hdmi_out/encode_r/n204_s3/I3           
+  4.834   1.099   tINS   FF   1        R22C43[2][A]   hdmi_out/encode_r/n204_s3/F            
+  4.834   0.000   tNET   FF   1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R22C46[2][A]   hdmi_out/encode_g/shr18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R22C46[2][A]   hdmi_out/encode_g/shr18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_1_s0      
+  2.653   -0.400   tSu         1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.706 25.391%, 
-                    route: 4.555 67.789%, 
-                    tC2Q: 0.458 6.821%)
+Arrival Data Path Delay: (cell: 2.131 50.002%, 
+                    route: 1.672 39.243%, 
+                    tC2Q: 0.458 10.754%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path6						
 Path Summary:
-Slack             : 2.297
-Data Arrival Time : 7.292
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : inv18_3_s0
+Slack             : -2.181
+Data Arrival Time : 4.834
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_4_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.035   2.004   tNET   FF   4        R5C45          hdmi_out/encode_b/tpa12_0_s7/RAD[0]    
-  3.294   0.259   tINS   FF   11       R5C45          hdmi_out/encode_b/tpa12_0_s7/DO[1]     
-  5.420   2.126   tNET   FF   1        R23C46[3][A]   hdmi_out/encode_g/n104_s2/I1           
-  6.045   0.625   tINS   FR   3        R23C46[3][A]   hdmi_out/encode_g/n104_s2/F            
-  6.470   0.425   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_g/n114_s0/I0           
-  7.292   0.822   tINS   RF   1        R22C46[2][B]   hdmi_out/encode_g/n114_s0/F            
-  7.292   0.000   tNET   FF   1        R22C46[2][B]   hdmi_out/encode_g/inv18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  3.735   0.850   tNET   FF   1        R22C43[1][A]   hdmi_out/encode_r/n201_s3/I3           
+  4.834   1.099   tINS   FF   1        R22C43[1][A]   hdmi_out/encode_r/n201_s3/F            
+  4.834   0.000   tNET   FF   1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R22C46[2][B]   hdmi_out/encode_g/inv18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R22C46[2][B]   hdmi_out/encode_g/inv18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_4_s0      
+  2.653   -0.400   tSu         1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.706 25.391%, 
-                    route: 4.555 67.789%, 
-                    tC2Q: 0.458 6.821%)
+Arrival Data Path Delay: (cell: 2.131 50.002%, 
+                    route: 1.672 39.243%, 
+                    tC2Q: 0.458 10.754%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path7						
 Path Summary:
-Slack             : 2.300
-Data Arrival Time : 7.288
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shl18_3_s0
+Slack             : -2.181
+Data Arrival Time : 4.834
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_5_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.035   2.004   tNET   FF   4        R5C45          hdmi_out/encode_b/tpa12_0_s7/RAD[0]    
-  3.294   0.259   tINS   FF   11       R5C45          hdmi_out/encode_b/tpa12_0_s7/DO[1]     
-  5.420   2.126   tNET   FF   1        R23C46[3][A]   hdmi_out/encode_g/n104_s2/I1           
-  6.045   0.625   tINS   FR   3        R23C46[3][A]   hdmi_out/encode_g/n104_s2/F            
-  6.466   0.421   tNET   RR   1        R24C46[0][B]   hdmi_out/encode_g/n132_s0/I1           
-  7.288   0.822   tINS   RF   1        R24C46[0][B]   hdmi_out/encode_g/n132_s0/F            
-  7.288   0.000   tNET   FF   1        R24C46[0][B]   hdmi_out/encode_g/shl18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  3.735   0.850   tNET   FF   1        R22C43[0][B]   hdmi_out/encode_r/n200_s3/I3           
+  4.834   1.099   tINS   FF   1        R22C43[0][B]   hdmi_out/encode_r/n200_s3/F            
+  4.834   0.000   tNET   FF   1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R24C46[0][B]   hdmi_out/encode_g/shl18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R24C46[0][B]   hdmi_out/encode_g/shl18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_5_s0      
+  2.653   -0.400   tSu         1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.706 25.406%, 
-                    route: 4.551 67.770%, 
-                    tC2Q: 0.458 6.825%)
+Arrival Data Path Delay: (cell: 2.131 50.002%, 
+                    route: 1.672 39.243%, 
+                    tC2Q: 0.458 10.754%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path8						
 Path Summary:
-Slack             : 2.376
-Data Arrival Time : 7.212
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shr18_3_s0
+Slack             : -2.181
+Data Arrival Time : 4.834
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_6_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.025   1.994   tNET   FF   4        R14C45         hdmi_out/encode_b/dat3_7_s11/RAD[0]    
-  3.284   0.259   tINS   FF   8        R14C45         hdmi_out/encode_b/dat3_7_s11/DO[1]     
-  4.937   1.654   tNET   FF   1        R2C45[3][A]    hdmi_out/encode_r/n104_s2/I2           
-  5.963   1.026   tINS   FR   3        R2C45[3][A]    hdmi_out/encode_r/n104_s2/F            
-  6.390   0.427   tNET   RR   1        R3C45[1][A]    hdmi_out/encode_r/n123_s0/I1           
-  7.212   0.822   tINS   RF   1        R3C45[1][A]    hdmi_out/encode_r/n123_s0/F            
-  7.212   0.000   tNET   FF   1        R3C45[1][A]    hdmi_out/encode_r/shr18_3_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  3.735   0.850   tNET   FF   1        R22C43[0][A]   hdmi_out/encode_r/n199_s3/I3           
+  4.834   1.099   tINS   FF   1        R22C43[0][A]   hdmi_out/encode_r/n199_s3/F            
+  4.834   0.000   tNET   FF   1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======== ====== ==== ======== ============= ======================================= 
-  9.416   9.416                                       active clock edge time                 
-  9.416   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R3C45[1][A]   hdmi_out/encode_r/shr18_3_s0/CLK       
-  9.588   -0.400   tSu         1        R3C45[1][A]   hdmi_out/encode_r/shr18_3_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_6_s0      
+  2.653   -0.400   tSu         1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 2.107 31.734%, 
-                    route: 4.075 61.364%, 
-                    tC2Q: 0.458 6.902%)
+Arrival Data Path Delay: (cell: 2.131 50.002%, 
+                    route: 1.672 39.243%, 
+                    tC2Q: 0.458 10.754%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path9						
 Path Summary:
-Slack             : 2.437
-Data Arrival Time : 7.151
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_pos18_2_s0
+Slack             : -1.781
+Data Arrival Time : 4.434
+Data Required Time: 2.653
+From              : bias_1_s0
+To                : o_tmds_0_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.685   2.655   tNET   FF   4        R14C40         hdmi_out/encode_b/enc11_0_s7/RAD[0]    
-  3.944   0.259   tINS   FF   3        R14C40         hdmi_out/encode_b/enc11_0_s7/DO[2]     
-  6.052   2.108   tNET   FF   1        R9C46[0][B]    hdmi_out/encode_b/n154_s2/I0           
-  7.151   1.099   tINS   FF   1        R9C46[0][B]    hdmi_out/encode_b/n154_s2/F            
-  7.151   0.000   tNET   FF   1        R9C46[0][B]    hdmi_out/encode_b/tmds_pos18_2_s0/D    
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/CLK        
+  1.030   0.458   tC2Q   RF   4        R22C46[2][B]   hdmi_out/encode_r/bias_1_s0/Q          
+  1.853   0.822   tNET   FF   1        R23C45[2][B]   hdmi_out/encode_r/n196_s3/I1           
+  2.885   1.032   tINS   FF   13       R23C45[2][B]   hdmi_out/encode_r/n196_s3/F            
+  3.402   0.517   tNET   FF   1        R23C43[0][A]   hdmi_out/encode_r/n205_s3/I3           
+  4.434   1.032   tINS   FF   1        R23C43[0][A]   hdmi_out/encode_r/n205_s3/F            
+  4.434   0.000   tNET   FF   1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0/D        
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======== ====== ==== ======== ============= ======================================= 
-  9.416   9.416                                       active clock edge time                 
-  9.416   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R9C46[0][B]   hdmi_out/encode_b/tmds_pos18_2_s0/CLK  
-  9.588   -0.400   tSu         1        R9C46[0][B]   hdmi_out/encode_b/tmds_pos18_2_s0      
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_0_s0      
+  2.653   -0.400   tSu         1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
+Clock Skew: -0.572
+Setup Relationship: 3.083
 Logic Level: 3
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.643%, 
-                    route: 4.763 72.390%, 
-                    tC2Q: 0.458 6.966%)
+Arrival Data Path Delay: (cell: 2.064 53.440%, 
+                    route: 1.340 34.693%, 
+                    tC2Q: 0.458 11.867%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path10						
 Path Summary:
-Slack             : 2.511
-Data Arrival Time : 7.077
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_0_s0
+Slack             : -0.455
+Data Arrival Time : 3.109
+Data Required Time: 2.653
+From              : tmds_even18_8_s0
+To                : o_tmds_8_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.978   2.675   tNET   FF   1        R22C43[1][B]   hdmi_out/encode_g/n143_s0/I0           
-  7.077   1.099   tINS   FF   1        R22C43[1][B]   hdmi_out/encode_g/n143_s0/F            
-  7.077   0.000   tNET   FF   1        R22C43[1][B]   hdmi_out/encode_g/tmds_even18_0_s0/D   
+ ======= ======= ====== ==== ======== ============= ======================================== 
+  0.000   0.000                                      active clock edge time                  
+  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]    hdmi_clock_div/CLKOUT                   
+  0.572   0.242   tNET   RR   1        R8C42[1][A]   hdmi_out/encode_r/tmds_even18_8_s0/CLK  
+  1.030   0.458   tC2Q   RF   1        R8C42[1][A]   hdmi_out/encode_r/tmds_even18_8_s0/Q    
+  3.109   2.078   tNET   FF   1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0/D         
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R22C43[1][B]   hdmi_out/encode_g/tmds_even18_0_s0/CLK  
-  9.588   -0.400   tSu         1        R22C43[1][B]   hdmi_out/encode_g/tmds_even18_0_s0      
+   AT     DELAY    TYPE   RF   FANOUT       LOC                     NODE                 
+ ======= ======== ====== ==== ======== ============= =================================== 
+  3.083   3.083                                       active clock edge time             
+  3.083   0.000                                       hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0/CLK  
+  3.053   -0.030   tUnc                               hdmi_out/encode_r/o_tmds_8_s0      
+  2.653   -0.400   tSu         1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.878%, 
-                    route: 4.689 72.076%, 
-                    tC2Q: 0.458 7.046%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 2.078 81.930%, 
+                    tC2Q: 0.458 18.070%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path11						
 Path Summary:
-Slack             : 2.511
-Data Arrival Time : 7.077
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_1_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_6_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.978   2.675   tNET   FF   1        R22C43[1][A]   hdmi_out/encode_g/n144_s0/I0           
-  7.077   1.099   tINS   FF   1        R22C43[1][A]   hdmi_out/encode_g/n144_s0/F            
-  7.077   0.000   tNET   FF   1        R22C43[1][A]   hdmi_out/encode_g/tmds_even18_1_s0/D   
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D6                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R22C43[1][A]   hdmi_out/encode_g/tmds_even18_1_s0/CLK  
-  9.588   -0.400   tSu         1        R22C43[1][A]   hdmi_out/encode_g/tmds_even18_1_s0      
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.878%, 
-                    route: 4.689 72.076%, 
-                    tC2Q: 0.458 7.046%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path12						
 Path Summary:
-Slack             : 2.511
-Data Arrival Time : 7.077
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_5_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_5_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.978   2.675   tNET   FF   1        R22C43[2][B]   hdmi_out/encode_g/n148_s0/I0           
-  7.077   1.099   tINS   FF   1        R22C43[2][B]   hdmi_out/encode_g/n148_s0/F            
-  7.077   0.000   tNET   FF   1        R22C43[2][B]   hdmi_out/encode_g/tmds_even18_5_s0/D   
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D5                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R22C43[2][B]   hdmi_out/encode_g/tmds_even18_5_s0/CLK  
-  9.588   -0.400   tSu         1        R22C43[2][B]   hdmi_out/encode_g/tmds_even18_5_s0      
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.878%, 
-                    route: 4.689 72.076%, 
-                    tC2Q: 0.458 7.046%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path13						
 Path Summary:
-Slack             : 2.511
-Data Arrival Time : 7.077
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_6_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_4_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.978   2.675   tNET   FF   1        R22C43[2][A]   hdmi_out/encode_g/n149_s0/I0           
-  7.077   1.099   tINS   FF   1        R22C43[2][A]   hdmi_out/encode_g/n149_s0/F            
-  7.077   0.000   tNET   FF   1        R22C43[2][A]   hdmi_out/encode_g/tmds_even18_6_s0/D   
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D4                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R22C43[2][A]   hdmi_out/encode_g/tmds_even18_6_s0/CLK  
-  9.588   -0.400   tSu         1        R22C43[2][A]   hdmi_out/encode_g/tmds_even18_6_s0      
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.878%, 
-                    route: 4.689 72.076%, 
-                    tC2Q: 0.458 7.046%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path14						
 Path Summary:
-Slack             : 2.531
-Data Arrival Time : 7.058
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shl18_0_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_3_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.959   2.655   tNET   FF   1        R23C46[2][A]   hdmi_out/encode_g/n135_s0/I1           
-  7.058   1.099   tINS   FF   1        R23C46[2][A]   hdmi_out/encode_g/n135_s0/F            
-  7.058   0.000   tNET   FF   1        R23C46[2][A]   hdmi_out/encode_g/shl18_0_s0/D         
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R23C44[2][A]   hdmi_out/encode_r/o_tmds_3_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R23C44[2][A]   hdmi_out/encode_r/o_tmds_3_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D3                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C46[2][A]   hdmi_out/encode_g/shl18_0_s0/CLK       
-  9.588   -0.400   tSu         1        R23C46[2][A]   hdmi_out/encode_g/shl18_0_s0           
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.941%, 
-                    route: 4.669 71.992%, 
-                    tC2Q: 0.458 7.067%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path15						
 Path Summary:
-Slack             : 2.531
-Data Arrival Time : 7.058
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shl18_1_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_2_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.959   2.655   tNET   FF   1        R23C46[1][B]   hdmi_out/encode_g/n134_s0/I1           
-  7.058   1.099   tINS   FF   1        R23C46[1][B]   hdmi_out/encode_g/n134_s0/F            
-  7.058   0.000   tNET   FF   1        R23C46[1][B]   hdmi_out/encode_g/shl18_1_s0/D         
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R23C44[2][B]   hdmi_out/encode_r/o_tmds_2_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R23C44[2][B]   hdmi_out/encode_r/o_tmds_2_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D2                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C46[1][B]   hdmi_out/encode_g/shl18_1_s0/CLK       
-  9.588   -0.400   tSu         1        R23C46[1][B]   hdmi_out/encode_g/shl18_1_s0           
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.941%, 
-                    route: 4.669 71.992%, 
-                    tC2Q: 0.458 7.067%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path16						
 Path Summary:
-Slack             : 2.531
-Data Arrival Time : 7.058
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shr18_0_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_1_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.959   2.655   tNET   FF   1        R23C46[2][B]   hdmi_out/encode_g/n126_s1/I1           
-  7.058   1.099   tINS   FF   1        R23C46[2][B]   hdmi_out/encode_g/n126_s1/F            
-  7.058   0.000   tNET   FF   1        R23C46[2][B]   hdmi_out/encode_g/shr18_0_s0/D         
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D1                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C46[2][B]   hdmi_out/encode_g/shr18_0_s0/CLK       
-  9.588   -0.400   tSu         1        R23C46[2][B]   hdmi_out/encode_g/shr18_0_s0           
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.941%, 
-                    route: 4.669 71.992%, 
-                    tC2Q: 0.458 7.067%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path17						
 Path Summary:
-Slack             : 2.531
-Data Arrival Time : 7.058
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : inv18_1_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : -0.277
+Data Arrival Time : 16.191
+Data Required Time: 15.914
+From              : o_tmds_0_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.959   2.655   tNET   FF   1        R23C46[1][A]   hdmi_out/encode_g/n116_s0/I1           
-  7.058   1.099   tINS   FF   1        R23C46[1][A]   hdmi_out/encode_g/n116_s0/F            
-  7.058   0.000   tNET   FF   1        R23C46[1][A]   hdmi_out/encode_g/inv18_1_s0/D         
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0/Q    
+  16.191   3.399    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D0                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C46[1][A]   hdmi_out/encode_g/inv18_1_s0/CLK       
-  9.588   -0.400   tSu         1        R23C46[1][A]   hdmi_out/encode_g/inv18_1_s0           
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.941%, 
-                    route: 4.669 71.992%, 
-                    tC2Q: 0.458 7.067%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.399 88.119%, 
+                    tC2Q: 0.458 11.881%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path18						
 Path Summary:
-Slack             : 2.540
-Data Arrival Time : 7.048
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shl18_2_s0
+Slack             : -0.030
+Data Arrival Time : 3.040
+Data Required Time: 3.010
+From              : not_den18_s0
+To                : o_tmds_8_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.949   2.645   tNET   FF   1        R23C45[1][A]   hdmi_out/encode_g/n133_s1/I0           
-  7.048   1.099   tINS   FF   1        R23C45[1][A]   hdmi_out/encode_g/n133_s1/F            
-  7.048   0.000   tNET   FF   1        R23C45[1][A]   hdmi_out/encode_g/shl18_2_s0/D         
+   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
+ ======= ======= ====== ==== ======== ============= ======================================= 
+  0.000   0.000                                      active clock edge time                 
+  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R9C44[1][A]   hdmi_out/encode_b/not_den18_s0/CLK     
+  1.030   0.458   tC2Q   RR   43       R9C44[1][A]   hdmi_out/encode_b/not_den18_s0/Q       
+  3.040   2.010   tNET   RR   1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0/SET      
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C45[1][A]   hdmi_out/encode_g/shl18_2_s0/CLK       
-  9.588   -0.400   tSu         1        R23C45[1][A]   hdmi_out/encode_g/shl18_2_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                     NODE                 
+ ======= ======== ====== ==== ======== ============= =================================== 
+  3.083   3.083                                       active clock edge time             
+  3.083   0.000                                       hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0/CLK  
+  3.053   -0.030   tUnc                               hdmi_out/encode_r/o_tmds_8_s0      
+  3.010   -0.043   tSu         1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 20.973%, 
-                    route: 4.659 71.949%, 
-                    tC2Q: 0.458 7.078%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 2.010 81.431%, 
+                    tC2Q: 0.458 18.569%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path19						
 Path Summary:
-Slack             : 2.560
-Data Arrival Time : 7.028
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_4_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : 0.037
+Data Arrival Time : 15.877
+Data Required Time: 15.914
+From              : o_tmds_9_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.929   2.626   tNET   FF   1        R24C43[1][A]   hdmi_out/encode_g/n147_s0/I0           
-  7.028   1.099   tINS   FF   1        R24C43[1][A]   hdmi_out/encode_g/n147_s0/F            
-  7.028   0.000   tNET   FF   1        R24C43[1][A]   hdmi_out/encode_g/tmds_even18_4_s0/D   
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R22C42[0][A]   hdmi_out/encode_r/o_tmds_9_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R22C42[0][A]   hdmi_out/encode_r/o_tmds_9_s0/Q    
+  15.877   3.085    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D9                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R24C43[1][A]   hdmi_out/encode_g/tmds_even18_4_s0/CLK  
-  9.588   -0.400   tSu         1        R24C43[1][A]   hdmi_out/encode_g/tmds_even18_4_s0      
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 21.037%, 
-                    route: 4.640 71.864%, 
-                    tC2Q: 0.458 7.099%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 3.085 87.065%, 
+                    tC2Q: 0.458 12.935%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path20						
 Path Summary:
-Slack             : 2.578
-Data Arrival Time : 7.367
-Data Required Time: 9.945
-From              : x_5_s0
-To                : y_0_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Slack             : 0.207
+Data Arrival Time : 15.707
+Data Required Time: 15.914
+From              : o_tmds_7_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C39[2][B]   ds/x_5_s0/CLK                          
-  1.030   0.458   tC2Q   RR   5        R13C39[2][B]   ds/x_5_s0/Q                            
-  1.454   0.423   tNET   RR   1        R13C39[3][B]   ds/n14_s2/I1                           
-  2.553   1.099   tINS   RF   1        R13C39[3][B]   ds/n14_s2/F                            
-  3.357   0.804   tNET   FF   1        R14C39[3][B]   ds/n14_s0/I1                           
-  4.383   1.026   tINS   FR   27       R14C39[3][B]   ds/n14_s0/F                            
-  4.813   0.431   tNET   RR   1        R15C39[3][A]   ds/n77_s1/I0                           
-  5.874   1.061   tINS   RR   13       R15C39[3][A]   ds/n77_s1/F                            
-  7.367   1.493   tNET   RR   1        R25C41[0][A]   ds/y_0_s0/RESET                        
+    AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======== ======== ====== ==== ======== ============== =================================== 
+  12.333   12.333                                       active clock edge time             
+  12.333   0.000                                        hdmi_clk_5x                        
+  12.333   0.000    tCL    RR   1        R22C42[0][B]   hdmi_out/encode_r/o_tmds_7_s0/CLK  
+  12.792   0.458    tC2Q   RF   1        R22C42[0][B]   hdmi_out/encode_r/o_tmds_7_s0/Q    
+  15.707   2.915    tNET   FF   1        IOT38[A]       hdmi_out/ser_c2/D7                 
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R25C41[0][A]   ds/y_0_s0/CLK                          
-  9.945   -0.043   tSu         1        R25C41[0][A]   ds/y_0_s0                              
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.989   0.242    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.959   -0.030   tUnc                              hdmi_out/ser_c2                        
+  15.914   -0.045   tSu         1        IOT38[A]     hdmi_out/ser_c2                        
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 4
+Clock Skew: 0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 3.186 46.887%, 
-                    route: 3.151 46.368%, 
-                    tC2Q: 0.458 6.745%)
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 2.915 86.412%, 
+                    tC2Q: 0.458 13.588%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
 
 						Path21						
 Path Summary:
-Slack             : 2.578
-Data Arrival Time : 7.010
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_2_s0
+Slack             : 0.252
+Data Arrival Time : 2.758
+Data Required Time: 3.010
+From              : not_den18_s0
+To                : o_tmds_1_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.978   2.675   tNET   FF   1        R22C43[0][B]   hdmi_out/encode_g/n145_s0/I0           
-  7.010   1.032   tINS   FF   1        R22C43[0][B]   hdmi_out/encode_g/n145_s0/F            
-  7.010   0.000   tNET   FF   1        R22C43[0][B]   hdmi_out/encode_g/tmds_even18_2_s0/D   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/CLK     
+  1.030   0.458   tC2Q   RR   43       R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/Q       
+  2.758   1.728   tNET   RR   1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0/RESET    
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R22C43[0][B]   hdmi_out/encode_g/tmds_even18_2_s0/CLK  
-  9.588   -0.400   tSu         1        R22C43[0][B]   hdmi_out/encode_g/tmds_even18_2_s0      
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_1_s0      
+  3.010   -0.043   tSu         1        R22C43[2][A]   hdmi_out/encode_r/o_tmds_1_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.291 20.055%, 
-                    route: 4.689 72.826%, 
-                    tC2Q: 0.458 7.119%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 1.728 79.033%, 
+                    tC2Q: 0.458 20.967%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path22						
 Path Summary:
-Slack             : 2.578
-Data Arrival Time : 7.010
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_3_s0
+Slack             : 0.252
+Data Arrival Time : 2.758
+Data Required Time: 3.010
+From              : not_den18_s0
+To                : o_tmds_4_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.978   2.675   tNET   FF   1        R22C43[0][A]   hdmi_out/encode_g/n146_s0/I0           
-  7.010   1.032   tINS   FF   1        R22C43[0][A]   hdmi_out/encode_g/n146_s0/F            
-  7.010   0.000   tNET   FF   1        R22C43[0][A]   hdmi_out/encode_g/tmds_even18_3_s0/D   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/CLK     
+  1.030   0.458   tC2Q   RR   43       R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/Q       
+  2.758   1.728   tNET   RR   1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0/SET      
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R22C43[0][A]   hdmi_out/encode_g/tmds_even18_3_s0/CLK  
-  9.588   -0.400   tSu         1        R22C43[0][A]   hdmi_out/encode_g/tmds_even18_3_s0      
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_4_s0      
+  3.010   -0.043   tSu         1        R22C43[1][A]   hdmi_out/encode_r/o_tmds_4_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.291 20.055%, 
-                    route: 4.689 72.826%, 
-                    tC2Q: 0.458 7.119%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 1.728 79.033%, 
+                    tC2Q: 0.458 20.967%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path23						
 Path Summary:
-Slack             : 2.602
-Data Arrival Time : 6.987
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : tmds_even18_2_s0
+Slack             : 0.252
+Data Arrival Time : 2.758
+Data Required Time: 3.010
+From              : not_den18_s0
+To                : o_tmds_5_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.685   2.655   tNET   FF   4        R14C40         hdmi_out/encode_b/enc11_0_s7/RAD[0]    
-  3.944   0.259   tINS   FF   3        R14C40         hdmi_out/encode_b/enc11_0_s7/DO[2]     
-  5.888   1.944   tNET   FF   1        R11C46[0][B]   hdmi_out/encode_b/n145_s0/I1           
-  6.987   1.099   tINS   FF   1        R11C46[0][B]   hdmi_out/encode_b/n145_s0/F            
-  6.987   0.000   tNET   FF   1        R11C46[0][B]   hdmi_out/encode_b/tmds_even18_2_s0/D   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/CLK     
+  1.030   0.458   tC2Q   RR   43       R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/Q       
+  2.758   1.728   tNET   RR   1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0/RESET    
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                         NODE                   
- ======= ======== ====== ==== ======== ============== ======================================== 
-  9.416   9.416                                        active clock edge time                  
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk   
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
-  9.988   0.242    tNET   RR   1        R11C46[0][B]   hdmi_out/encode_b/tmds_even18_2_s0/CLK  
-  9.588   -0.400   tSu         1        R11C46[0][B]   hdmi_out/encode_b/tmds_even18_2_s0      
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_5_s0      
+  3.010   -0.043   tSu         1        R22C43[0][B]   hdmi_out/encode_r/o_tmds_5_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.358 21.173%, 
-                    route: 4.598 71.682%, 
-                    tC2Q: 0.458 7.145%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 1.728 79.033%, 
+                    tC2Q: 0.458 20.967%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path24						
 Path Summary:
-Slack             : 2.607
-Data Arrival Time : 6.981
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : shr18_2_s0
+Slack             : 0.252
+Data Arrival Time : 2.758
+Data Required Time: 3.010
+From              : not_den18_s0
+To                : o_tmds_6_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.949   2.645   tNET   FF   1        R23C45[0][B]   hdmi_out/encode_g/n124_s1/I0           
-  6.981   1.032   tINS   FF   1        R23C45[0][B]   hdmi_out/encode_g/n124_s1/F            
-  6.981   0.000   tNET   FF   1        R23C45[0][B]   hdmi_out/encode_g/shr18_2_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/CLK     
+  1.030   0.458   tC2Q   RR   43       R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/Q       
+  2.758   1.728   tNET   RR   1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0/SET      
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C45[0][B]   hdmi_out/encode_g/shr18_2_s0/CLK       
-  9.588   -0.400   tSu         1        R23C45[0][B]   hdmi_out/encode_g/shr18_2_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_6_s0      
+  3.010   -0.043   tSu         1        R22C43[0][A]   hdmi_out/encode_r/o_tmds_6_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.291 20.147%, 
-                    route: 4.659 72.701%, 
-                    tC2Q: 0.458 7.152%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 1.728 79.033%, 
+                    tC2Q: 0.458 20.967%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 						Path25						
 Path Summary:
-Slack             : 2.607
-Data Arrival Time : 6.981
-Data Required Time: 9.588
-From              : enc11_0_s2
-To                : inv18_2_s0
+Slack             : 0.267
+Data Arrival Time : 2.743
+Data Required Time: 3.010
+From              : not_den18_s0
+To                : o_tmds_0_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clk_5x:[R]
 
 Data Arrival Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.572   0.242   tNET   RR   1        R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/CLK       
-  1.030   0.458   tC2Q   RF   31       R13C44[0][B]   hdmi_out/encode_b/enc11_0_s2/Q         
-  3.044   2.014   tNET   FF   4        R6C45          hdmi_out/encode_b/par9_s9/RAD[0]       
-  3.304   0.259   tINS   FF   21       R6C45          hdmi_out/encode_b/par9_s9/DO[1]        
-  5.949   2.645   tNET   FF   1        R23C45[0][A]   hdmi_out/encode_g/n115_s2/I2           
-  6.981   1.032   tINS   FF   1        R23C45[0][A]   hdmi_out/encode_g/n115_s2/F            
-  6.981   0.000   tNET   FF   1        R23C45[0][A]   hdmi_out/encode_g/inv18_2_s0/D         
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.572   0.242   tNET   RR   1        R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/CLK     
+  1.030   0.458   tC2Q   RR   43       R9C44[1][A]    hdmi_out/encode_b/not_den18_s0/Q       
+  2.743   1.713   tNET   RR   1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0/RESET    
 
 Data Required Path:
-   AT     DELAY    TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======== ====== ==== ======== ============== ======================================= 
-  9.416   9.416                                        active clock edge time                 
-  9.416   0.000                                        hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330    tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  9.988   0.242    tNET   RR   1        R23C45[0][A]   hdmi_out/encode_g/inv18_2_s0/CLK       
-  9.588   -0.400   tSu         1        R23C45[0][A]   hdmi_out/encode_g/inv18_2_s0           
+   AT     DELAY    TYPE   RF   FANOUT       LOC                      NODE                 
+ ======= ======== ====== ==== ======== ============== =================================== 
+  3.083   3.083                                        active clock edge time             
+  3.083   0.000                                        hdmi_clk_5x                        
+  3.083   0.000    tCL    RR   1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0/CLK  
+  3.053   -0.030   tUnc                                hdmi_out/encode_r/o_tmds_0_s0      
+  3.010   -0.043   tSu         1        R23C43[0][A]   hdmi_out/encode_r/o_tmds_0_s0      
 
 Path Statistics:
-Clock Skew: 0.000
-Setup Relationship: 9.416
-Logic Level: 3
+Clock Skew: -0.572
+Setup Relationship: 3.083
+Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.242 100.000%)
-Arrival Data Path Delay: (cell: 1.291 20.147%, 
-                    route: 4.659 72.701%, 
-                    tC2Q: 0.458 7.152%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 1.713 78.892%, 
+                    tC2Q: 0.458 21.108%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.242 100.000%)
+                     route: 0.000 0.000%)
 
 3.3.2 Hold Analysis Report
 Report Command:report_timing -hold -max_paths 25 -max_common_paths 1
 						Path1						
 Path Summary:
-Slack             : 0.550
-Data Arrival Time : 1.078
+Slack             : 0.556
+Data Arrival Time : 1.084
 Data Required Time: 0.528
-From              : ctl2_0_s0
-To                : ctl3_0_s9
+From              : enc10_3_s0
+To                : tpb11_3_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
@@ -1361,19 +1267,19 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R16C46[1][A]   hdmi_out/encode_b/ctl2_0_s0/CLK        
-  0.846   0.333   tC2Q   RF   1        R16C46[1][A]   hdmi_out/encode_b/ctl2_0_s0/Q          
-  1.078   0.231   tNET   FF   1        R15C46         hdmi_out/encode_b/ctl3_0_s9/DI[0]      
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R22C45[0][B]   hdmi_out/encode_r/enc10_3_s0/CLK       
+  0.846   0.333   tC2Q   RR   2        R22C45[0][B]   hdmi_out/encode_r/enc10_3_s0/Q         
+  1.084   0.238   tNET   RR   1        R22C45[1][A]   hdmi_out/encode_r/tpb11_3_s0/RESET     
 
 Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT      LOC                       NODE                   
- ======= ======= ====== ==== ======== ============ ======================================= 
-  0.000   0.000                                     active clock edge time                 
-  0.000   0.000                                     hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C46       hdmi_out/encode_b/ctl3_0_s9/CLK        
-  0.528   0.015   tHld        1        R15C46       hdmi_out/encode_b/ctl3_0_s9            
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R22C45[1][A]   hdmi_out/encode_r/tpb11_3_s0/CLK       
+  0.528   0.015   tHld        1        R22C45[1][A]   hdmi_out/encode_r/tpb11_3_s0           
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1382,39 +1288,39 @@ Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.231 40.960%, 
-                    tC2Q: 0.333 59.040%)
+                    route: 0.238 41.613%, 
+                    tC2Q: 0.333 58.387%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
 						Path2						
 Path Summary:
-Slack             : 0.553
-Data Arrival Time : 1.081
+Slack             : 0.556
+Data Arrival Time : 1.084
 Data Required Time: 0.528
-From              : enc10_6_s0
-To                : enc11_0_s12
+From              : dat3_3_s0
+To                : par4_1_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R14C45[0][A]   hdmi_out/encode_r/enc10_6_s0/CLK       
-  0.846   0.333   tC2Q   RF   2        R14C45[0][A]   hdmi_out/encode_r/enc10_6_s0/Q         
-  1.081   0.234   tNET   FF   1        R14C44         hdmi_out/encode_b/enc11_0_s12/DI[2]    
+   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
+ ======= ======= ====== ==== ======== ============= ======================================= 
+  0.000   0.000                                      active clock edge time                 
+  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R5C43[0][A]   hdmi_out/encode_g/dat3_3_s0/CLK        
+  0.846   0.333   tC2Q   RR   3        R5C43[0][A]   hdmi_out/encode_g/dat3_3_s0/Q          
+  1.084   0.238   tNET   RR   1        R5C43[2][A]   hdmi_out/encode_g/par4_1_s0/SET        
 
 Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT      LOC                       NODE                   
- ======= ======= ====== ==== ======== ============ ======================================= 
-  0.000   0.000                                     active clock edge time                 
-  0.000   0.000                                     hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R14C44       hdmi_out/encode_b/enc11_0_s12/CLK      
-  0.528   0.015   tHld        1        R14C44       hdmi_out/encode_b/enc11_0_s12          
+   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
+ ======= ======= ====== ==== ======== ============= ======================================= 
+  0.000   0.000                                      active clock edge time                 
+  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R5C43[2][A]   hdmi_out/encode_g/par4_1_s0/CLK        
+  0.528   0.015   tHld        1        R5C43[2][A]   hdmi_out/encode_g/par4_1_s0            
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1423,18 +1329,18 @@ Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.234 41.295%, 
-                    tC2Q: 0.333 58.705%)
+                    route: 0.238 41.613%, 
+                    tC2Q: 0.333 58.387%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
 						Path3						
 Path Summary:
-Slack             : 0.553
-Data Arrival Time : 1.081
+Slack             : 0.556
+Data Arrival Time : 1.084
 Data Required Time: 0.528
-From              : enc10_4_s0
-To                : enc11_0_s8
+From              : enc10_3_s0
+To                : tpb11_3_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
@@ -1443,19 +1349,19 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C43[1][B]   hdmi_out/encode_b/enc10_4_s0/CLK       
-  0.846   0.333   tC2Q   RF   2        R15C43[1][B]   hdmi_out/encode_b/enc10_4_s0/Q         
-  1.081   0.234   tNET   FF   1        R15C42         hdmi_out/encode_b/enc11_0_s8/DI[0]     
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C46[2][B]   hdmi_out/encode_b/enc10_3_s0/CLK       
+  0.846   0.333   tC2Q   RR   2        R16C46[2][B]   hdmi_out/encode_b/enc10_3_s0/Q         
+  1.084   0.238   tNET   RR   1        R16C46[1][A]   hdmi_out/encode_b/tpb11_3_s0/RESET     
 
 Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT      LOC                       NODE                   
- ======= ======= ====== ==== ======== ============ ======================================= 
-  0.000   0.000                                     active clock edge time                 
-  0.000   0.000                                     hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C42       hdmi_out/encode_b/enc11_0_s8/CLK       
-  0.528   0.015   tHld        1        R15C42       hdmi_out/encode_b/enc11_0_s8           
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C46[1][A]   hdmi_out/encode_b/tpb11_3_s0/CLK       
+  0.528   0.015   tHld        1        R16C46[1][A]   hdmi_out/encode_b/tpb11_3_s0           
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1464,8 +1370,8 @@ Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.234 41.295%, 
-                    tC2Q: 0.333 58.705%)
+                    route: 0.238 41.613%, 
+                    tC2Q: 0.333 58.387%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
@@ -1474,29 +1380,29 @@ Path Summary:
 Slack             : 0.556
 Data Arrival Time : 1.084
 Data Required Time: 0.528
-From              : enc10_1_s0
-To                : tpb11_1_s0
+From              : dat3_3_s0
+To                : par4_1_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R2C42[0][A]   hdmi_out/encode_r/enc10_1_s0/CLK       
-  0.846   0.333   tC2Q   RR   2        R2C42[0][A]   hdmi_out/encode_r/enc10_1_s0/Q         
-  1.084   0.238   tNET   RR   1        R2C42[2][A]   hdmi_out/encode_r/tpb11_1_s0/RESET     
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R20C44[1][A]   hdmi_out/encode_b/dat3_3_s0/CLK        
+  0.846   0.333   tC2Q   RR   3        R20C44[1][A]   hdmi_out/encode_b/dat3_3_s0/Q          
+  1.084   0.238   tNET   RR   1        R20C44[2][A]   hdmi_out/encode_b/par4_1_s0/SET        
 
 Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R2C42[2][A]   hdmi_out/encode_r/tpb11_1_s0/CLK       
-  0.528   0.015   tHld        1        R2C42[2][A]   hdmi_out/encode_r/tpb11_1_s0           
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R20C44[2][A]   hdmi_out/encode_b/par4_1_s0/CLK        
+  0.528   0.015   tHld        1        R20C44[2][A]   hdmi_out/encode_b/par4_1_s0            
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1512,213 +1418,8 @@ Required Clock Path Delay: (cell: 0.000 0.000%,
 
 						Path5						
 Path Summary:
-Slack             : 0.556
-Data Arrival Time : 1.084
-Data Required Time: 0.528
-From              : enc10_3_s0
-To                : tpb11_3_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R7C42[0][B]   hdmi_out/encode_r/enc10_3_s0/CLK       
-  0.846   0.333   tC2Q   RR   2        R7C42[0][B]   hdmi_out/encode_r/enc10_3_s0/Q         
-  1.084   0.238   tNET   RR   1        R7C42[2][A]   hdmi_out/encode_r/tpb11_3_s0/RESET     
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R7C42[2][A]   hdmi_out/encode_r/tpb11_3_s0/CLK       
-  0.528   0.015   tHld        1        R7C42[2][A]   hdmi_out/encode_r/tpb11_3_s0           
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 1
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.238 41.613%, 
-                    tC2Q: 0.333 58.387%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path6						
-Path Summary:
-Slack             : 0.556
-Data Arrival Time : 1.084
-Data Required Time: 0.528
-From              : enc10_1_s0
-To                : tpb11_1_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R16C45[2][A]   hdmi_out/encode_b/enc10_1_s0/CLK       
-  0.846   0.333   tC2Q   RR   2        R16C45[2][A]   hdmi_out/encode_b/enc10_1_s0/Q         
-  1.084   0.238   tNET   RR   1        R16C45[1][A]   hdmi_out/encode_b/tpb11_1_s0/RESET     
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R16C45[1][A]   hdmi_out/encode_b/tpb11_1_s0/CLK       
-  0.528   0.015   tHld        1        R16C45[1][A]   hdmi_out/encode_b/tpb11_1_s0           
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 1
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.238 41.613%, 
-                    tC2Q: 0.333 58.387%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path7						
-Path Summary:
-Slack             : 0.556
-Data Arrival Time : 1.084
-Data Required Time: 0.528
-From              : enc10_3_s0
-To                : tpb11_3_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C44[2][B]   hdmi_out/encode_b/enc10_3_s0/CLK       
-  0.846   0.333   tC2Q   RR   2        R13C44[2][B]   hdmi_out/encode_b/enc10_3_s0/Q         
-  1.084   0.238   tNET   RR   1        R13C44[1][B]   hdmi_out/encode_b/tpb11_3_s0/RESET     
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C44[1][B]   hdmi_out/encode_b/tpb11_3_s0/CLK       
-  0.528   0.015   tHld        1        R13C44[1][B]   hdmi_out/encode_b/tpb11_3_s0           
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 1
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.238 41.613%, 
-                    tC2Q: 0.333 58.387%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path8						
-Path Summary:
-Slack             : 0.569
-Data Arrival Time : 1.097
-Data Required Time: 0.528
-From              : enc11_0_s6
-To                : den2_s10
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6/CLK       
-  0.846   0.333   tC2Q   RF   15       R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6/Q         
-  1.097   0.251   tNET   FF   1        R5C46         hdmi_out/encode_r/den2_s10/AD[2]       
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT      LOC                       NODE                   
- ======= ======= ====== ==== ======== ============ ======================================= 
-  0.000   0.000                                     active clock edge time                 
-  0.000   0.000                                     hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R5C46        hdmi_out/encode_r/den2_s10/CLK         
-  0.528   0.015   tHld        1        R5C46        hdmi_out/encode_r/den2_s10             
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 1
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.251 42.919%, 
-                    tC2Q: 0.333 57.081%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path9						
-Path Summary:
-Slack             : 0.572
-Data Arrival Time : 1.100
-Data Required Time: 0.528
-From              : enc11_0_s4
-To                : den2_s10
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R6C46[1][B]   hdmi_out/encode_b/enc11_0_s4/CLK       
-  0.846   0.333   tC2Q   RF   18       R6C46[1][B]   hdmi_out/encode_b/enc11_0_s4/Q         
-  1.100   0.254   tNET   FF   1        R5C46         hdmi_out/encode_r/den2_s10/AD[1]       
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT      LOC                       NODE                   
- ======= ======= ====== ==== ======== ============ ======================================= 
-  0.000   0.000                                     active clock edge time                 
-  0.000   0.000                                     hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R5C46        hdmi_out/encode_r/den2_s10/CLK         
-  0.528   0.015   tHld        1        R5C46        hdmi_out/encode_r/den2_s10             
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 1
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.254 43.233%, 
-                    tC2Q: 0.333 56.767%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path10						
-Path Summary:
-Slack             : 0.584
-Data Arrival Time : 1.113
+Slack             : 0.557
+Data Arrival Time : 1.085
 Data Required Time: 0.528
 From              : dat4_4_s0
 To                : par5_1_s0
@@ -1730,19 +1431,19 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R18C43[0][B]   hdmi_out/encode_b/dat4_4_s0/CLK        
-  0.846   0.333   tC2Q   RR   4        R18C43[0][B]   hdmi_out/encode_b/dat4_4_s0/Q          
-  1.113   0.266   tNET   RR   1        R18C45[2][B]   hdmi_out/encode_b/par5_1_s0/SET        
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R20C43[1][B]   hdmi_out/encode_b/dat4_4_s0/CLK        
+  0.846   0.333   tC2Q   RR   4        R20C43[1][B]   hdmi_out/encode_b/dat4_4_s0/Q          
+  1.085   0.239   tNET   RR   1        R20C43[2][A]   hdmi_out/encode_b/par5_1_s0/SET        
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R18C45[2][B]   hdmi_out/encode_b/par5_1_s0/CLK        
-  0.528   0.015   tHld        1        R18C45[2][B]   hdmi_out/encode_b/par5_1_s0            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R20C43[2][A]   hdmi_out/encode_b/par5_1_s0/CLK        
+  0.528   0.015   tHld        1        R20C43[2][A]   hdmi_out/encode_b/par5_1_s0            
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1751,59 +1452,18 @@ Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.266 44.393%, 
-                    tC2Q: 0.333 55.607%)
+                    route: 0.239 41.734%, 
+                    tC2Q: 0.333 58.266%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path11						
+						Path6						
 Path Summary:
-Slack             : 0.587
-Data Arrival Time : 1.115
+Slack             : 0.562
+Data Arrival Time : 1.090
 Data Required Time: 0.528
-From              : ctl3_0_s8
-To                : den2_s10
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8/CLK        
-  0.846   0.333   tC2Q   RR   5        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8/Q          
-  1.115   0.268   tNET   RR   1        R5C46         hdmi_out/encode_r/den2_s10/AD[3]       
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT      LOC                       NODE                   
- ======= ======= ====== ==== ======== ============ ======================================= 
-  0.000   0.000                                     active clock edge time                 
-  0.000   0.000                                     hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R5C46        hdmi_out/encode_r/den2_s10/CLK         
-  0.528   0.015   tHld        1        R5C46        hdmi_out/encode_r/den2_s10             
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 1
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.268 44.611%, 
-                    tC2Q: 0.333 55.389%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path12						
-Path Summary:
-Slack             : 0.588
-Data Arrival Time : 1.116
-Data Required Time: 0.528
-From              : dat2_2_s0
-To                : par3_1_s0
+From              : dat3_3_s0
+To                : par4_3_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
@@ -1812,19 +1472,19 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R20C46[0][B]   hdmi_out/encode_b/dat2_2_s0/CLK        
-  0.846   0.333   tC2Q   RR   4        R20C46[0][B]   hdmi_out/encode_b/dat2_2_s0/Q          
-  1.116   0.270   tNET   RR   1        R20C44[2][A]   hdmi_out/encode_b/par3_1_s0/SET        
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R26C41[1][B]   hdmi_out/encode_r/dat3_3_s0/CLK        
+  0.846   0.333   tC2Q   RR   3        R26C41[1][B]   hdmi_out/encode_r/dat3_3_s0/Q          
+  1.090   0.244   tNET   RR   1        R26C41[2][A]   hdmi_out/encode_r/par4_3_s0/RESET      
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R20C44[2][A]   hdmi_out/encode_b/par3_1_s0/CLK        
-  0.528   0.015   tHld        1        R20C44[2][A]   hdmi_out/encode_b/par3_1_s0            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R26C41[2][A]   hdmi_out/encode_r/par4_3_s0/CLK        
+  0.528   0.015   tHld        1        R26C41[2][A]   hdmi_out/encode_r/par4_3_s0            
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1833,18 +1493,18 @@ Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.270 44.739%, 
-                    tC2Q: 0.333 55.261%)
+                    route: 0.244 42.242%, 
+                    tC2Q: 0.333 57.758%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path13						
+						Path7						
 Path Summary:
-Slack             : 0.588
-Data Arrival Time : 1.116
-Data Required Time: 0.528
-From              : dat2_2_s0
-To                : par3_2_s0
+Slack             : 0.570
+Data Arrival Time : 1.083
+Data Required Time: 0.513
+From              : enc7_1_s0
+To                : enc8_1_s0
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
@@ -1853,19 +1513,19 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R20C46[0][B]   hdmi_out/encode_b/dat2_2_s0/CLK        
-  0.846   0.333   tC2Q   RR   4        R20C46[0][B]   hdmi_out/encode_b/dat2_2_s0/Q          
-  1.116   0.270   tNET   RR   1        R20C45[2][A]   hdmi_out/encode_b/par3_2_s0/RESET      
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R22C46[0][A]   hdmi_out/encode_r/enc7_1_s0/CLK        
+  0.846   0.333   tC2Q   RR   1        R22C46[0][A]   hdmi_out/encode_r/enc7_1_s0/Q          
+  1.083   0.236   tNET   RR   1        R22C46[1][B]   hdmi_out/encode_r/enc8_1_s0/D          
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R20C45[2][A]   hdmi_out/encode_b/par3_2_s0/CLK        
-  0.528   0.015   tHld        1        R20C45[2][A]   hdmi_out/encode_b/par3_2_s0            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R22C46[1][B]   hdmi_out/encode_r/enc8_1_s0/CLK        
+  0.513   0.000   tHld        1        R22C46[1][B]   hdmi_out/encode_r/enc8_1_s0            
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1874,12 +1534,94 @@ Logic Level: 1
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 Arrival Data Path Delay: (cell: 0.000 0.000%, 
-                    route: 0.270 44.739%, 
-                    tC2Q: 0.333 55.261%)
+                    route: 0.236 41.492%, 
+                    tC2Q: 0.333 58.508%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path14						
+						Path8						
+Path Summary:
+Slack             : 0.570
+Data Arrival Time : 1.083
+Data Required Time: 0.513
+From              : enc6_5_s0
+To                : enc7_5_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R22C45[2][A]   hdmi_out/encode_r/enc6_5_s0/CLK        
+  0.846   0.333   tC2Q   RR   1        R22C45[2][A]   hdmi_out/encode_r/enc6_5_s0/Q          
+  1.083   0.236   tNET   RR   1        R22C45[2][B]   hdmi_out/encode_r/enc7_5_s0/D          
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R22C45[2][B]   hdmi_out/encode_r/enc7_5_s0/CLK        
+  0.513   0.000   tHld        1        R22C45[2][B]   hdmi_out/encode_r/enc7_5_s0            
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 1
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 0.236 41.492%, 
+                    tC2Q: 0.333 58.508%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path9						
+Path Summary:
+Slack             : 0.609
+Data Arrival Time : 16.584
+Data Required Time: 15.975
+From              : o_tmds_8_s0
+To                : ser_c2
+Launch Clk        : hdmi_clk_5x:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+    AT     DELAY    TYPE   RF   FANOUT       LOC                     NODE                 
+ ======== ======== ====== ==== ======== ============= =================================== 
+  15.417   15.417                                      active clock edge time             
+  15.417   0.000                                       hdmi_clk_5x                        
+  15.417   0.000    tCL    RR   1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0/CLK  
+  15.750   0.333    tC2Q   RR   1        R3C41[1][B]   hdmi_out/encode_r/o_tmds_8_s0/Q    
+  16.584   0.834    tNET   RR   1        IOT38[A]      hdmi_out/ser_c2/D8                 
+
+Data Required Path:
+    AT     DELAY    TYPE   RF   FANOUT      LOC                       NODE                   
+ ======== ======== ====== ==== ======== ============ ======================================= 
+  15.417   15.417                                     active clock edge time                 
+  15.417   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330    tCL    RR   619      TOPSIDE[0]   hdmi_clock_div/CLKOUT                  
+  15.930   0.183    tNET   RR   1        IOT38[A]     hdmi_out/ser_c2/PCLK                   
+  15.960   0.030    tUnc                              hdmi_out/ser_c2                        
+  15.975   0.015    tHld        1        IOT38[A]     hdmi_out/ser_c2                        
+
+Path Statistics:
+Clock Skew: 0.513
+Hold Relationship: 0.000
+Logic Level: 1
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.000 0.000%)
+Arrival Data Path Delay: (cell: 0.000 0.000%, 
+                    route: 0.834 71.448%, 
+                    tC2Q: 0.333 28.552%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path10						
 Path Summary:
 Slack             : 0.708
 Data Arrival Time : 1.221
@@ -1890,25 +1632,25 @@ Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
 Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R8C45[0][A]   hdmi_out/encode_b/par9_s8/CLK          
-  0.846   0.333   tC2Q   RR   3        R8C45[0][A]   hdmi_out/encode_b/par9_s8/Q            
-  0.849   0.002   tNET   RR   1        R8C45[0][A]   hdmi_out/encode_b/par9_s13/I3          
-  1.221   0.372   tINS   RF   1        R8C45[0][A]   hdmi_out/encode_b/par9_s13/F           
-  1.221   0.000   tNET   FF   1        R8C45[0][A]   hdmi_out/encode_b/par9_s8/D            
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C44[0][A]   hdmi_out/encode_b/par9_s8/CLK          
+  0.846   0.333   tC2Q   RR   3        R13C44[0][A]   hdmi_out/encode_b/par9_s8/Q            
+  0.849   0.002   tNET   RR   1        R13C44[0][A]   hdmi_out/encode_b/par9_s13/I3          
+  1.221   0.372   tINS   RF   1        R13C44[0][A]   hdmi_out/encode_b/par9_s13/F           
+  1.221   0.000   tNET   FF   1        R13C44[0][A]   hdmi_out/encode_b/par9_s8/D            
 
 Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R8C45[0][A]   hdmi_out/encode_b/par9_s8/CLK          
-  0.513   0.000   tHld        1        R8C45[0][A]   hdmi_out/encode_b/par9_s8              
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C44[0][A]   hdmi_out/encode_b/par9_s8/CLK          
+  0.513   0.000   tHld        1        R13C44[0][A]   hdmi_out/encode_b/par9_s8              
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1922,13 +1664,13 @@ Arrival Data Path Delay: (cell: 0.372 52.565%,
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path15						
+						Path11						
 Path Summary:
-Slack             : 0.709
-Data Arrival Time : 1.222
+Slack             : 0.712
+Data Arrival Time : 1.226
 Data Required Time: 0.513
-From              : y_0_s0
-To                : y_0_s0
+From              : enc11_0_s4
+To                : enc11_0_s4
 Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
 
@@ -1937,21 +1679,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R25C41[0][A]   ds/y_0_s0/CLK                          
-  0.846   0.333   tC2Q   RR   5        R25C41[0][A]   ds/y_0_s0/Q                            
-  0.850   0.004   tNET   RR   1        R25C41[0][A]   ds/n76_s2/I0                           
-  1.222   0.372   tINS   RF   1        R25C41[0][A]   ds/n76_s2/F                            
-  1.222   0.000   tNET   FF   1        R25C41[0][A]   ds/y_0_s0/D                            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C46[1][A]   hdmi_out/encode_b/enc11_0_s4/CLK       
+  0.846   0.333   tC2Q   RR   16       R13C46[1][A]   hdmi_out/encode_b/enc11_0_s4/Q         
+  0.854   0.007   tNET   RR   1        R13C46[1][A]   hdmi_out/encode_b/tpa12_0_s9/I1        
+  1.226   0.372   tINS   RF   1        R13C46[1][A]   hdmi_out/encode_b/tpa12_0_s9/F         
+  1.226   0.000   tNET   FF   1        R13C46[1][A]   hdmi_out/encode_b/enc11_0_s4/D         
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R25C41[0][A]   ds/y_0_s0/CLK                          
-  0.513   0.000   tHld        1        R25C41[0][A]   ds/y_0_s0                              
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C46[1][A]   hdmi_out/encode_b/enc11_0_s4/CLK       
+  0.513   0.000   tHld        1        R13C46[1][A]   hdmi_out/encode_b/enc11_0_s4           
 
 Path Statistics:
 Clock Skew: 0.000
@@ -1959,188 +1701,16 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.372 52.478%, 
-                    route: 0.004 0.500%, 
-                    tC2Q: 0.333 47.023%)
+Arrival Data Path Delay: (cell: 0.372 52.217%, 
+                    route: 0.007 0.994%, 
+                    tC2Q: 0.333 46.789%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path16						
+						Path12						
 Path Summary:
-Slack             : 0.709
-Data Arrival Time : 1.222
-Data Required Time: 0.513
-From              : x_0_s0
-To                : x_0_s0
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C42[1][A]   ds/x_0_s0/CLK                          
-  0.846   0.333   tC2Q   RR   4        R13C42[1][A]   ds/x_0_s0/Q                            
-  0.850   0.004   tNET   RR   1        R13C42[1][A]   ds/n28_s2/I0                           
-  1.222   0.372   tINS   RF   1        R13C42[1][A]   ds/n28_s2/F                            
-  1.222   0.000   tNET   FF   1        R13C42[1][A]   ds/x_0_s0/D                            
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C42[1][A]   ds/x_0_s0/CLK                          
-  0.513   0.000   tHld        1        R13C42[1][A]   ds/x_0_s0                              
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 2
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.372 52.478%, 
-                    route: 0.004 0.500%, 
-                    tC2Q: 0.333 47.023%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path17						
-Path Summary:
-Slack             : 0.710
-Data Arrival Time : 1.223
-Data Required Time: 0.513
-From              : ctl3_0_s8
-To                : ctl3_0_s8
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8/CLK        
-  0.846   0.333   tC2Q   RR   5        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8/Q          
-  0.851   0.005   tNET   RR   1        R7C46[1][A]   hdmi_out/encode_r/den2_s14/I3          
-  1.223   0.372   tINS   RF   1        R7C46[1][A]   hdmi_out/encode_r/den2_s14/F           
-  1.223   0.000   tNET   FF   1        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8/D          
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8/CLK        
-  0.513   0.000   tHld        1        R7C46[1][A]   hdmi_out/encode_b/ctl3_0_s8            
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 2
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.372 52.390%, 
-                    route: 0.005 0.665%, 
-                    tC2Q: 0.333 46.945%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path18						
-Path Summary:
-Slack             : 0.711
-Data Arrival Time : 1.224
-Data Required Time: 0.513
-From              : dat3_7_s6
-To                : dat3_7_s6
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s6/CLK        
-  0.846   0.333   tC2Q   RR   7        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s6/Q          
-  0.852   0.006   tNET   RR   1        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s14/I2        
-  1.224   0.372   tINS   RF   1        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s14/F         
-  1.224   0.000   tNET   FF   1        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s6/D          
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
- ======= ======= ====== ==== ======== ============== ======================================= 
-  0.000   0.000                                       active clock edge time                 
-  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s6/CLK        
-  0.513   0.000   tHld        1        R13C45[1][A]   hdmi_out/encode_b/dat3_7_s6            
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 2
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.372 52.303%, 
-                    route: 0.006 0.830%, 
-                    tC2Q: 0.333 46.867%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path19						
-Path Summary:
-Slack             : 0.714
-Data Arrival Time : 1.227
-Data Required Time: 0.513
-From              : enc11_0_s6
-To                : enc11_0_s6
-Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
-
-Data Arrival Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6/CLK       
-  0.846   0.333   tC2Q   RR   15       R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6/Q         
-  0.855   0.008   tNET   RR   1        R6C46[1][A]   hdmi_out/encode_r/den2_s13/I2          
-  1.227   0.372   tINS   RF   1        R6C46[1][A]   hdmi_out/encode_r/den2_s13/F           
-  1.227   0.000   tNET   FF   1        R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6/D         
-
-Data Required Path:
-   AT     DELAY   TYPE   RF   FANOUT       LOC                       NODE                   
- ======= ======= ====== ==== ======== ============= ======================================= 
-  0.000   0.000                                      active clock edge time                 
-  0.000   0.000                                      hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]    hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6/CLK       
-  0.513   0.000   tHld        1        R6C46[1][A]   hdmi_out/encode_b/enc11_0_s6           
-
-Path Statistics:
-Clock Skew: 0.000
-Hold Relationship: 0.000
-Logic Level: 2
-Arrival Clock Path delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.372 52.130%, 
-                    route: 0.008 1.158%, 
-                    tC2Q: 0.333 46.712%)
-Required Clock Path Delay: (cell: 0.000 0.000%, 
-                     route: 0.183 100.000%)
-
-						Path20						
-Path Summary:
-Slack             : 0.730
-Data Arrival Time : 1.243
+Slack             : 0.731
+Data Arrival Time : 1.244
 Data Required Time: 0.513
 From              : y_6_s0
 To                : y_6_s0
@@ -2152,21 +1722,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C40[0][A]   ds/y_6_s0/CLK                          
-  0.846   0.333   tC2Q   RR   4        R15C40[0][A]   ds/y_6_s0/Q                            
-  0.849   0.002   tNET   RR   2        R15C40[0][A]   ds/n70_s/I1                            
-  1.243   0.394   tINS   RF   1        R15C40[0][A]   ds/n70_s/SUM                           
-  1.243   0.000   tNET   FF   1        R15C40[0][A]   ds/y_6_s0/D                            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C40[0][A]   ds/y_6_s0/CLK                          
+  0.846   0.333   tC2Q   RR   4        R13C40[0][A]   ds/y_6_s0/Q                            
+  0.850   0.004   tNET   RR   2        R13C40[0][A]   ds/n71_s/I1                            
+  1.244   0.394   tINS   RF   1        R13C40[0][A]   ds/n71_s/SUM                           
+  1.244   0.000   tNET   FF   1        R13C40[0][A]   ds/y_6_s0/D                            
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C40[0][A]   ds/y_6_s0/CLK                          
-  0.513   0.000   tHld        1        R15C40[0][A]   ds/y_6_s0                              
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C40[0][A]   ds/y_6_s0/CLK                          
+  0.513   0.000   tHld        1        R13C40[0][A]   ds/y_6_s0                              
 
 Path Statistics:
 Clock Skew: 0.000
@@ -2174,16 +1744,16 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.394 53.995%, 
-                    route: 0.002 0.324%, 
-                    tC2Q: 0.333 45.681%)
+Arrival Data Path Delay: (cell: 0.394 53.908%, 
+                    route: 0.004 0.485%, 
+                    tC2Q: 0.333 45.607%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path21						
+						Path13						
 Path Summary:
-Slack             : 0.730
-Data Arrival Time : 1.243
+Slack             : 0.731
+Data Arrival Time : 1.244
 Data Required Time: 0.513
 From              : y_8_s0
 To                : y_8_s0
@@ -2195,21 +1765,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C40[1][A]   ds/y_8_s0/CLK                          
-  0.846   0.333   tC2Q   RR   3        R15C40[1][A]   ds/y_8_s0/Q                            
-  0.849   0.002   tNET   RR   2        R15C40[1][A]   ds/n68_s/I1                            
-  1.243   0.394   tINS   RF   1        R15C40[1][A]   ds/n68_s/SUM                           
-  1.243   0.000   tNET   FF   1        R15C40[1][A]   ds/y_8_s0/D                            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C40[1][A]   ds/y_8_s0/CLK                          
+  0.846   0.333   tC2Q   RR   3        R13C40[1][A]   ds/y_8_s0/Q                            
+  0.850   0.004   tNET   RR   2        R13C40[1][A]   ds/n69_s/I1                            
+  1.244   0.394   tINS   RF   1        R13C40[1][A]   ds/n69_s/SUM                           
+  1.244   0.000   tNET   FF   1        R13C40[1][A]   ds/y_8_s0/D                            
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C40[1][A]   ds/y_8_s0/CLK                          
-  0.513   0.000   tHld        1        R15C40[1][A]   ds/y_8_s0                              
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C40[1][A]   ds/y_8_s0/CLK                          
+  0.513   0.000   tHld        1        R13C40[1][A]   ds/y_8_s0                              
 
 Path Statistics:
 Clock Skew: 0.000
@@ -2217,16 +1787,16 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.394 53.995%, 
-                    route: 0.002 0.324%, 
-                    tC2Q: 0.333 45.681%)
+Arrival Data Path Delay: (cell: 0.394 53.908%, 
+                    route: 0.004 0.485%, 
+                    tC2Q: 0.333 45.607%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path22						
+						Path14						
 Path Summary:
-Slack             : 0.730
-Data Arrival Time : 1.243
+Slack             : 0.731
+Data Arrival Time : 1.244
 Data Required Time: 0.513
 From              : x_2_s0
 To                : x_2_s0
@@ -2238,21 +1808,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C39[1][A]   ds/x_2_s0/CLK                          
-  0.846   0.333   tC2Q   RR   3        R13C39[1][A]   ds/x_2_s0/Q                            
-  0.849   0.002   tNET   RR   2        R13C39[1][A]   ds/n26_s/I1                            
-  1.243   0.394   tINS   RF   1        R13C39[1][A]   ds/n26_s/SUM                           
-  1.243   0.000   tNET   FF   1        R13C39[1][A]   ds/x_2_s0/D                            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C39[1][A]   ds/x_2_s0/CLK                          
+  0.846   0.333   tC2Q   RR   3        R16C39[1][A]   ds/x_2_s0/Q                            
+  0.850   0.004   tNET   RR   2        R16C39[1][A]   ds/n27_s/I1                            
+  1.244   0.394   tINS   RF   1        R16C39[1][A]   ds/n27_s/SUM                           
+  1.244   0.000   tNET   FF   1        R16C39[1][A]   ds/x_2_s0/D                            
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C39[1][A]   ds/x_2_s0/CLK                          
-  0.513   0.000   tHld        1        R13C39[1][A]   ds/x_2_s0                              
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C39[1][A]   ds/x_2_s0/CLK                          
+  0.513   0.000   tHld        1        R16C39[1][A]   ds/x_2_s0                              
 
 Path Statistics:
 Clock Skew: 0.000
@@ -2260,16 +1830,59 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.394 53.995%, 
-                    route: 0.002 0.324%, 
-                    tC2Q: 0.333 45.681%)
+Arrival Data Path Delay: (cell: 0.394 53.908%, 
+                    route: 0.004 0.485%, 
+                    tC2Q: 0.333 45.607%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path23						
+						Path15						
 Path Summary:
 Slack             : 0.731
 Data Arrival Time : 1.244
+Data Required Time: 0.513
+From              : x_8_s0
+To                : x_8_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C40[1][A]   ds/x_8_s0/CLK                          
+  0.846   0.333   tC2Q   RR   4        R16C40[1][A]   ds/x_8_s0/Q                            
+  0.850   0.004   tNET   RR   2        R16C40[1][A]   ds/n21_s/I1                            
+  1.244   0.394   tINS   RF   1        R16C40[1][A]   ds/n21_s/SUM                           
+  1.244   0.000   tNET   FF   1        R16C40[1][A]   ds/x_8_s0/D                            
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C40[1][A]   ds/x_8_s0/CLK                          
+  0.513   0.000   tHld        1        R16C40[1][A]   ds/x_8_s0                              
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.394 53.908%, 
+                    route: 0.004 0.485%, 
+                    tC2Q: 0.333 45.607%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path16						
+Path Summary:
+Slack             : 0.732
+Data Arrival Time : 1.245
 Data Required Time: 0.513
 From              : x_12_s0
 To                : x_12_s0
@@ -2281,21 +1894,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C41[0][A]   ds/x_12_s0/CLK                         
-  0.846   0.333   tC2Q   RR   4        R13C41[0][A]   ds/x_12_s0/Q                           
-  0.850   0.004   tNET   RR   2        R13C41[0][A]   ds/n16_s/I1                            
-  1.244   0.394   tINS   RF   1        R13C41[0][A]   ds/n16_s/SUM                           
-  1.244   0.000   tNET   FF   1        R13C41[0][A]   ds/x_12_s0/D                           
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C41[0][A]   ds/x_12_s0/CLK                         
+  0.846   0.333   tC2Q   RR   5        R16C41[0][A]   ds/x_12_s0/Q                           
+  0.851   0.005   tNET   RR   2        R16C41[0][A]   ds/n17_s/I1                            
+  1.245   0.394   tINS   RF   1        R16C41[0][A]   ds/n17_s/SUM                           
+  1.245   0.000   tNET   FF   1        R16C41[0][A]   ds/x_12_s0/D                           
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R13C41[0][A]   ds/x_12_s0/CLK                         
-  0.513   0.000   tHld        1        R13C41[0][A]   ds/x_12_s0                             
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C41[0][A]   ds/x_12_s0/CLK                         
+  0.513   0.000   tHld        1        R16C41[0][A]   ds/x_12_s0                             
 
 Path Statistics:
 Clock Skew: 0.000
@@ -2303,16 +1916,16 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.394 53.908%, 
-                    route: 0.004 0.485%, 
-                    tC2Q: 0.333 45.607%)
+Arrival Data Path Delay: (cell: 0.394 53.821%, 
+                    route: 0.005 0.645%, 
+                    tC2Q: 0.333 45.534%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path24						
+						Path17						
 Path Summary:
-Slack             : 0.731
-Data Arrival Time : 1.244
+Slack             : 0.732
+Data Arrival Time : 1.245
 Data Required Time: 0.513
 From              : y_12_s0
 To                : y_12_s0
@@ -2324,21 +1937,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C41[0][A]   ds/y_12_s0/CLK                         
-  0.846   0.333   tC2Q   RR   4        R15C41[0][A]   ds/y_12_s0/Q                           
-  0.850   0.004   tNET   RR   2        R15C41[0][A]   ds/n64_s/I1                            
-  1.244   0.394   tINS   RF   1        R15C41[0][A]   ds/n64_s/SUM                           
-  1.244   0.000   tNET   FF   1        R15C41[0][A]   ds/y_12_s0/D                           
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C41[0][A]   ds/y_12_s0/CLK                         
+  0.846   0.333   tC2Q   RR   5        R13C41[0][A]   ds/y_12_s0/Q                           
+  0.851   0.005   tNET   RR   2        R13C41[0][A]   ds/n65_s/I1                            
+  1.245   0.394   tINS   RF   1        R13C41[0][A]   ds/n65_s/SUM                           
+  1.245   0.000   tNET   FF   1        R13C41[0][A]   ds/y_12_s0/D                           
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C41[0][A]   ds/y_12_s0/CLK                         
-  0.513   0.000   tHld        1        R15C41[0][A]   ds/y_12_s0                             
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C41[0][A]   ds/y_12_s0/CLK                         
+  0.513   0.000   tHld        1        R13C41[0][A]   ds/y_12_s0                             
 
 Path Statistics:
 Clock Skew: 0.000
@@ -2346,16 +1959,59 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.394 53.908%, 
-                    route: 0.004 0.485%, 
-                    tC2Q: 0.333 45.607%)
+Arrival Data Path Delay: (cell: 0.394 53.821%, 
+                    route: 0.005 0.645%, 
+                    tC2Q: 0.333 45.534%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
-						Path25						
+						Path18						
 Path Summary:
 Slack             : 0.732
 Data Arrival Time : 1.245
+Data Required Time: 0.513
+From              : x_6_s0
+To                : x_6_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C40[0][A]   ds/x_6_s0/CLK                          
+  0.846   0.333   tC2Q   RR   4        R16C40[0][A]   ds/x_6_s0/Q                            
+  0.851   0.005   tNET   RR   2        R16C40[0][A]   ds/n23_s/I1                            
+  1.245   0.394   tINS   RF   1        R16C40[0][A]   ds/n23_s/SUM                           
+  1.245   0.000   tNET   FF   1        R16C40[0][A]   ds/x_6_s0/D                            
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R16C40[0][A]   ds/x_6_s0/CLK                          
+  0.513   0.000   tHld        1        R16C40[0][A]   ds/x_6_s0                              
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.394 53.821%, 
+                    route: 0.005 0.645%, 
+                    tC2Q: 0.333 45.534%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path19						
+Path Summary:
+Slack             : 0.733
+Data Arrival Time : 1.246
 Data Required Time: 0.513
 From              : y_2_s0
 To                : y_2_s0
@@ -2367,21 +2023,21 @@ Data Arrival Path:
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C39[1][A]   ds/y_2_s0/CLK                          
-  0.846   0.333   tC2Q   RR   4        R15C39[1][A]   ds/y_2_s0/Q                            
-  0.851   0.005   tNET   RR   2        R15C39[1][A]   ds/n74_s/I1                            
-  1.245   0.394   tINS   RF   1        R15C39[1][A]   ds/n74_s/SUM                           
-  1.245   0.000   tNET   FF   1        R15C39[1][A]   ds/y_2_s0/D                            
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C39[1][A]   ds/y_2_s0/CLK                          
+  0.846   0.333   tC2Q   RR   5        R13C39[1][A]   ds/y_2_s0/Q                            
+  0.852   0.006   tNET   RR   2        R13C39[1][A]   ds/n75_s/I1                            
+  1.246   0.394   tINS   RF   1        R13C39[1][A]   ds/n75_s/SUM                           
+  1.246   0.000   tNET   FF   1        R13C39[1][A]   ds/y_2_s0/D                            
 
 Data Required Path:
    AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
  ======= ======= ====== ==== ======== ============== ======================================= 
   0.000   0.000                                       active clock edge time                 
   0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
-  0.330   0.330   tCL    RR   632      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
-  0.513   0.183   tNET   RR   1        R15C39[1][A]   ds/y_2_s0/CLK                          
-  0.513   0.000   tHld        1        R15C39[1][A]   ds/y_2_s0                              
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C39[1][A]   ds/y_2_s0/CLK                          
+  0.513   0.000   tHld        1        R13C39[1][A]   ds/y_2_s0                              
 
 Path Statistics:
 Clock Skew: 0.000
@@ -2389,9 +2045,267 @@ Hold Relationship: 0.000
 Logic Level: 2
 Arrival Clock Path delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
-Arrival Data Path Delay: (cell: 0.394 53.821%, 
-                    route: 0.005 0.645%, 
-                    tC2Q: 0.333 45.534%)
+Arrival Data Path Delay: (cell: 0.394 53.734%, 
+                    route: 0.006 0.805%, 
+                    tC2Q: 0.333 45.461%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path20						
+Path Summary:
+Slack             : 0.769
+Data Arrival Time : 1.282
+Data Required Time: 0.513
+From              : par9_s8
+To                : tmds_even18_9_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C44[0][A]   hdmi_out/encode_b/par9_s8/CLK          
+  0.846   0.333   tC2Q   RF   3        R13C44[0][A]   hdmi_out/encode_b/par9_s8/Q            
+  1.109   0.263   tNET   FF   4        R14C44         hdmi_out/encode_b/par9_s9/RAD[3]       
+  1.282   0.173   tINS   FR   21       R14C44         hdmi_out/encode_b/par9_s9/DO[2]        
+  1.282   0.000   tNET   RR   1        R14C44[1][A]   hdmi_out/encode_r/tmds_even18_9_s0/D   
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                         NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================== 
+  0.000   0.000                                       active clock edge time                  
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
+  0.513   0.183   tNET   RR   1        R14C44[1][A]   hdmi_out/encode_r/tmds_even18_9_s0/CLK  
+  0.513   0.000   tHld        1        R14C44[1][A]   hdmi_out/encode_r/tmds_even18_9_s0      
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.173 22.533%, 
+                    route: 0.263 34.134%, 
+                    tC2Q: 0.333 43.333%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path21						
+Path Summary:
+Slack             : 0.769
+Data Arrival Time : 1.282
+Data Required Time: 0.513
+From              : par9_s8
+To                : tmds_even18_9_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C44[0][A]   hdmi_out/encode_b/par9_s8/CLK          
+  0.846   0.333   tC2Q   RF   3        R13C44[0][A]   hdmi_out/encode_b/par9_s8/Q            
+  1.109   0.263   tNET   FF   4        R14C44         hdmi_out/encode_b/par9_s9/RAD[3]       
+  1.282   0.173   tINS   FR   21       R14C44         hdmi_out/encode_b/par9_s9/DO[1]        
+  1.282   0.000   tNET   RR   1        R14C44[0][B]   hdmi_out/encode_g/tmds_even18_9_s0/D   
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                         NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================== 
+  0.000   0.000                                       active clock edge time                  
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
+  0.513   0.183   tNET   RR   1        R14C44[0][B]   hdmi_out/encode_g/tmds_even18_9_s0/CLK  
+  0.513   0.000   tHld        1        R14C44[0][B]   hdmi_out/encode_g/tmds_even18_9_s0      
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.173 22.533%, 
+                    route: 0.263 34.134%, 
+                    tC2Q: 0.333 43.333%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path22						
+Path Summary:
+Slack             : 0.769
+Data Arrival Time : 1.282
+Data Required Time: 0.513
+From              : par9_s8
+To                : tmds_even18_9_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C44[0][A]   hdmi_out/encode_b/par9_s8/CLK          
+  0.846   0.333   tC2Q   RF   3        R13C44[0][A]   hdmi_out/encode_b/par9_s8/Q            
+  1.109   0.263   tNET   FF   4        R14C44         hdmi_out/encode_b/par9_s9/RAD[3]       
+  1.282   0.173   tINS   FR   21       R14C44         hdmi_out/encode_b/par9_s9/DO[0]        
+  1.282   0.000   tNET   RR   1        R14C44[0][A]   hdmi_out/encode_b/tmds_even18_9_s0/D   
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                         NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================== 
+  0.000   0.000                                       active clock edge time                  
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk   
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                   
+  0.513   0.183   tNET   RR   1        R14C44[0][A]   hdmi_out/encode_b/tmds_even18_9_s0/CLK  
+  0.513   0.000   tHld        1        R14C44[0][A]   hdmi_out/encode_b/tmds_even18_9_s0      
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.173 22.533%, 
+                    route: 0.263 34.134%, 
+                    tC2Q: 0.333 43.333%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path23						
+Path Summary:
+Slack             : 0.775
+Data Arrival Time : 1.288
+Data Required Time: 0.513
+From              : enc11_0_s6
+To                : tmds_neg18_0_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C46[0][B]   hdmi_out/encode_b/enc11_0_s6/CLK       
+  0.846   0.333   tC2Q   RF   13       R13C46[0][B]   hdmi_out/encode_b/enc11_0_s6/Q         
+  1.114   0.268   tNET   FF   4        R14C46         hdmi_out/encode_b/enc11_0_s9/RAD[2]    
+  1.288   0.173   tINS   FR   3        R14C46         hdmi_out/encode_b/enc11_0_s9/DO[0]     
+  1.288   0.000   tNET   RR   1        R14C46[0][A]   hdmi_out/encode_g/tmds_neg18_0_s0/D    
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R14C46[0][A]   hdmi_out/encode_g/tmds_neg18_0_s0/CLK  
+  0.513   0.000   tHld        1        R14C46[0][A]   hdmi_out/encode_g/tmds_neg18_0_s0      
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.173 22.378%, 
+                    route: 0.268 34.587%, 
+                    tC2Q: 0.333 43.035%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path24						
+Path Summary:
+Slack             : 0.775
+Data Arrival Time : 1.288
+Data Required Time: 0.513
+From              : enc11_0_s6
+To                : tmds_neg18_1_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C46[0][B]   hdmi_out/encode_b/enc11_0_s6/CLK       
+  0.846   0.333   tC2Q   RF   13       R13C46[0][B]   hdmi_out/encode_b/enc11_0_s6/Q         
+  1.114   0.268   tNET   FF   4        R14C46         hdmi_out/encode_b/enc11_0_s9/RAD[2]    
+  1.288   0.173   tINS   FR   3        R14C46         hdmi_out/encode_b/enc11_0_s9/DO[1]     
+  1.288   0.000   tNET   RR   1        R14C46[0][B]   hdmi_out/encode_g/tmds_neg18_1_s0/D    
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R14C46[0][B]   hdmi_out/encode_g/tmds_neg18_1_s0/CLK  
+  0.513   0.000   tHld        1        R14C46[0][B]   hdmi_out/encode_g/tmds_neg18_1_s0      
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.173 22.378%, 
+                    route: 0.268 34.587%, 
+                    tC2Q: 0.333 43.035%)
+Required Clock Path Delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+
+						Path25						
+Path Summary:
+Slack             : 0.775
+Data Arrival Time : 1.288
+Data Required Time: 0.513
+From              : enc11_0_s6
+To                : tmds_neg18_2_s0
+Launch Clk        : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+Latch Clk         : hdmi_clock_div/CLKOUT.default_gen_clk:[R]
+
+Data Arrival Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R13C46[0][B]   hdmi_out/encode_b/enc11_0_s6/CLK       
+  0.846   0.333   tC2Q   RF   13       R13C46[0][B]   hdmi_out/encode_b/enc11_0_s6/Q         
+  1.114   0.268   tNET   FF   4        R14C46         hdmi_out/encode_b/enc11_0_s9/RAD[2]    
+  1.288   0.173   tINS   FR   3        R14C46         hdmi_out/encode_b/enc11_0_s9/DO[2]     
+  1.288   0.000   tNET   RR   1        R14C46[1][A]   hdmi_out/encode_g/tmds_neg18_2_s0/D    
+
+Data Required Path:
+   AT     DELAY   TYPE   RF   FANOUT       LOC                        NODE                   
+ ======= ======= ====== ==== ======== ============== ======================================= 
+  0.000   0.000                                       active clock edge time                 
+  0.000   0.000                                       hdmi_clock_div/CLKOUT.default_gen_clk  
+  0.330   0.330   tCL    RR   619      TOPSIDE[0]     hdmi_clock_div/CLKOUT                  
+  0.513   0.183   tNET   RR   1        R14C46[1][A]   hdmi_out/encode_g/tmds_neg18_2_s0/CLK  
+  0.513   0.000   tHld        1        R14C46[1][A]   hdmi_out/encode_g/tmds_neg18_2_s0      
+
+Path Statistics:
+Clock Skew: 0.000
+Hold Relationship: 0.000
+Logic Level: 2
+Arrival Clock Path delay: (cell: 0.000 0.000%, 
+                     route: 0.183 100.000%)
+Arrival Data Path Delay: (cell: 0.173 22.378%, 
+                    route: 0.268 34.587%, 
+                    tC2Q: 0.333 43.035%)
 Required Clock Path Delay: (cell: 0.000 0.000%, 
                      route: 0.183 100.000%)
 
@@ -2406,8 +2320,8 @@ Report Command:report_min_pulse_width -nworst 10 -detail
 
 								MPW1
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
@@ -2416,23 +2330,48 @@ Objects:        ds/x_11_s0
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   ds/x_11_s0/CLK                         
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   ds/x_11_s0/CLK                         
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   ds/x_11_s0/CLK                         
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   ds/x_11_s0/CLK                         
 
 								MPW2
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
+Required Width: 1.250
+Type:           Low Pulse Width
+Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
+Objects:        ds/x_10_s0
+
+Late clock Path:
+   AT     DELAY   TYPE   RF                   NODE                   
+ ======= ======= ====== ==== ======================================= 
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   ds/x_10_s0/CLK                         
+
+Early clock Path:
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   ds/x_10_s0/CLK                         
+
+								MPW3
+MPW Summary:
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
@@ -2441,248 +2380,223 @@ Objects:        ds/x_9_s0
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   ds/x_9_s0/CLK                          
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   ds/x_9_s0/CLK                          
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   ds/x_9_s0/CLK                          
-
-								MPW3
-MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
-Required Width: 1.250
-Type:           Low Pulse Width
-Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        ds/x_5_s0
-
-Late clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   ds/x_5_s0/CLK                          
-
-Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   ds/x_5_s0/CLK                          
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   ds/x_9_s0/CLK                          
 
 								MPW4
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        ds/y_10_s0
+Objects:        ds/o_y_6_s0
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   ds/y_10_s0/CLK                         
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   ds/o_y_6_s0/CLK                        
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   ds/y_10_s0/CLK                         
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   ds/o_y_6_s0/CLK                        
 
 								MPW5
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        ds/o_x_2_s0
+Objects:        hdmi_out/encode_b/enc9_5_s0
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   ds/o_x_2_s0/CLK                        
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   hdmi_out/encode_b/enc9_5_s0/CLK        
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   ds/o_x_2_s0/CLK                        
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   hdmi_out/encode_b/enc9_5_s0/CLK        
 
 								MPW6
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        hdmi_out/rgb_p_8_s0
+Objects:        hdmi_out/encode_b/tmds_pos18_3_s0
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   hdmi_out/rgb_p_8_s0/CLK                
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   hdmi_out/encode_b/tmds_pos18_3_s0/CLK  
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   hdmi_out/rgb_p_8_s0/CLK                
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   hdmi_out/encode_b/tmds_pos18_3_s0/CLK  
 
 								MPW7
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        hdmi_out/encode_b/par6_2_s0
+Objects:        hdmi_out/encode_b/ctl2_0_s8
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   hdmi_out/encode_b/par6_2_s0/CLK        
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   hdmi_out/encode_b/ctl2_0_s8/CLK        
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   hdmi_out/encode_b/par6_2_s0/CLK        
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   hdmi_out/encode_b/ctl2_0_s8/CLK        
 
 								MPW8
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        hdmi_out/encode_b/rst0_s0
+Objects:        hdmi_out/encode_g/dat1_6_s0
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   hdmi_out/encode_b/rst0_s0/CLK          
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   hdmi_out/encode_g/dat1_6_s0/CLK        
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   hdmi_out/encode_b/rst0_s0/CLK          
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   hdmi_out/encode_g/dat1_6_s0/CLK        
 
 								MPW9
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        hdmi_out/encode_r/enc6_7_s0
+Objects:        hdmi_out/encode_g/dat2_6_s0
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   hdmi_out/encode_r/enc6_7_s0/CLK        
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   hdmi_out/encode_g/dat2_6_s0/CLK        
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   hdmi_out/encode_r/enc6_7_s0/CLK        
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   hdmi_out/encode_g/dat2_6_s0/CLK        
 
 								MPW10
 MPW Summary:
-Slack:          3.384
-Actual Width:   4.634
+Slack:          6.384
+Actual Width:   7.634
 Required Width: 1.250
 Type:           Low Pulse Width
 Clock:          hdmi_clock_div/CLKOUT.default_gen_clk
-Objects:        hdmi_out/encode_r/enc5_1_s0
+Objects:        hdmi_out/encode_g/dat2_2_s0
 
 Late clock Path:
    AT     DELAY   TYPE   RF                   NODE                   
  ======= ======= ====== ==== ======================================= 
-  4.708   0.000               active clock edge time                 
-  4.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  5.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
-  5.295   0.257   tNET   FF   hdmi_out/encode_r/enc5_1_s0/CLK        
+  7.708   0.000               active clock edge time                 
+  7.708   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  8.038   0.330   tCL    FF   hdmi_clock_div/CLKOUT                  
+  8.295   0.257   tNET   FF   hdmi_out/encode_g/dat2_2_s0/CLK        
 
 Early clock Path:
-   AT     DELAY   TYPE   RF                   NODE                   
- ======= ======= ====== ==== ======================================= 
-  9.416   0.000               active clock edge time                 
-  9.416   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
-  9.746   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
-  9.929   0.183   tNET   RR   hdmi_out/encode_r/enc5_1_s0/CLK        
+    AT     DELAY   TYPE   RF                   NODE                   
+ ======== ======= ====== ==== ======================================= 
+  15.417   0.000               active clock edge time                 
+  15.417   0.000               hdmi_clock_div/CLKOUT.default_gen_clk  
+  15.747   0.330   tCL    RR   hdmi_clock_div/CLKOUT                  
+  15.930   0.183   tNET   RR   hdmi_out/encode_g/dat2_2_s0/CLK        
 
 3.5 High Fanout Nets Report
 Report Command:report_high_fanout_nets -max_nets 10
-  FANOUT     NET NAME     WORST SLACK   MAX DELAY  
- ======== ============== ============= =========== 
-  3805     adder_clk[0]   177.418       0.262      
-  632      hdmi_clk       1.985         0.659      
-  43       not_den18      3.905         5.038      
-  31       enc11_0_5      1.985         2.655      
-  27       n14_3          2.578         1.971      
-  27       den1           7.432         1.482      
-  21       par17_23       3.530         1.655      
-  21       par17          2.511         2.779      
-  21       par17_24       3.839         1.347      
-  18       enc11_0_9      3.262         2.186      
+  FANOUT   NET NAME    WORST SLACK   MAX DELAY  
+ ======== =========== ============= =========== 
+  3806     clk_d       29.233        0.262      
+  619      hdmi_clk    -3.539        0.257      
+  43       not_den18   -0.030        2.962      
+  29       enc11_0_5   8.347         1.998      
+  27       n15_3       8.205         1.805      
+  25       den1        11.977        2.938      
+  21       par17_23    10.300        1.810      
+  21       par17       9.813         2.125      
+  21       par17_24    9.576         2.257      
+  17       bias[3]     10.448        0.863      
 
 3.6 Route Congestions Report
 Report Command:report_route_congestion -max_grids 10
   GRID LOC   ROUTE CONGESTIONS  
  ========== =================== 
-  R3C42      0.847              
-  R3C2       0.833              
-  R23C43     0.833              
-  R13C43     0.833              
-  R6C46      0.819              
-  R22C42     0.819              
-  R13C40     0.819              
-  R2C46      0.806              
-  R18C44     0.806              
-  R5C43      0.806              
+  R16C40     0.889              
+  R13C44     0.847              
+  R14C45     0.847              
+  R3C44      0.833              
+  R13C46     0.833              
+  R3C4       0.819              
+  R4C4       0.819              
+  R17C43     0.819              
+  R9C43      0.819              
+  R16C45     0.819              
 
 3.7 Timing Exceptions Report
 3.7.1 Setup Analysis Report
@@ -2702,6 +2616,8 @@ Report Command:report_exceptions -removal -max_paths 5 -max_common_paths 1
 No timing exceptions to report!
 
 3.8 Timing Constraints Report
-  SDC Command Type   State   Detail Command  
- ================== ======= ================ 
+   SDC Command Type     State                                                                                                                                                                                                           Detail Command                                                                                                                                                                                                          
+ ==================== ========= =============================================================================================================================================================================================================================================================================================================================================================================================================================== 
+  TC_CLOCK             Actived   create_clock -name clk -period 37 -waveform {0 18} [get_ports {clk}] -add                                                                                                                                                                                                                                                                                                                                                      
+  TC_GENERATED_CLOCK   Actived   create_generated_clock -name hdmi_clk_5x -source [get_ports {clk}] -master_clock clk -multiply_by 12 [get_regs {hdmi_out/encode_r/o_tmds_0_s0 hdmi_out/encode_r/o_tmds_1_s0 hdmi_out/encode_r/o_tmds_2_s0 hdmi_out/encode_r/o_tmds_3_s0 hdmi_out/encode_r/o_tmds_4_s0 hdmi_out/encode_r/o_tmds_5_s0 hdmi_out/encode_r/o_tmds_6_s0 hdmi_out/encode_r/o_tmds_7_s0 hdmi_out/encode_r/o_tmds_8_s0 hdmi_out/encode_r/o_tmds_9_s0}]  
 

--- a/src/constraints.sdc
+++ b/src/constraints.sdc
@@ -1,0 +1,7 @@
+//Copyright (C)2014-2023 GOWIN Semiconductor Corporation.
+//All rights reserved.
+//File Title: Timing Constraints file
+//GOWIN Version: 1.9.8.09 Education
+//Created Time: 2023-04-22 18:37:24
+create_clock -name clk -period 37 -waveform {0 18} [get_ports {clk}] -add
+create_generated_clock -name hdmi_clk_5x -source [get_ports {clk}] -master_clock clk -multiply_by 12 [get_regs {hdmi_out/encode_r/o_tmds_0_s0 hdmi_out/encode_r/o_tmds_1_s0 hdmi_out/encode_r/o_tmds_2_s0 hdmi_out/encode_r/o_tmds_3_s0 hdmi_out/encode_r/o_tmds_4_s0 hdmi_out/encode_r/o_tmds_5_s0 hdmi_out/encode_r/o_tmds_6_s0 hdmi_out/encode_r/o_tmds_7_s0 hdmi_out/encode_r/o_tmds_8_s0 hdmi_out/encode_r/o_tmds_9_s0}]


### PR DESCRIPTION
Gowin ide seem unable to calculate properly all timings because there is  no timing paths to get frequency of hdmi_clk_5x . [Gowin documentation](http://cdn.gowinsemi.com.cn/SUG940E.pdf) section 5.1.3 (see notes) recommend to add complete timing constraint to the design. 

The constraint I added is from port clk to the output registers of tmds_encoder module. 

```
module tmds_encoder(
  input i_hdmi_clk,         // HDMI pixel clock
  input i_reset,            // reset (active high)
  input [7:0] i_data,       // Input 8-bit color
  input [1:0] i_ctrl,       // control data (vsync and hsync)
  input i_display_enable,   // high=pixel data active. low=display is in blanking area
  output reg [9:0] o_tmds   // encoded 10-bit TMDS data
);
```
Then I see violation in Setup Paths Table in Timing Analys Report. 




